### PR TITLE
fix dockerfile to use 'WORKDIR' to set working directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.8
-RUN cd /usr/local/lib/python3.8/site-packages
+WORKDIR /usr/local/lib/python3.8/site-packages
 RUN git clone https://github.com/networktocode/ntc-templates.git
 RUN mv ntc-templates ntc_templates
 ADD . /code


### PR DESCRIPTION
Using 'RUN cd ...' doesn't persist to the next 'RUN' command.  Consequence of this is the existing Dockerfile winds up putting the ntc_templates folder at `/` instead of nested in `/site-packages` as expected by the app.  

Another alternative would probably be 
```
RUN cd /usr/local/lib/python3.8/site-packages && \
    git clone https://github.com/networktocode/ntc-templates.git && \
    mv ntc-templates ntc_templates
```
