### PR TITLE
Fix missing jsonschema lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ rq
 xmltodict
 jinja2
 jinja2schema
+jsonschema


### PR DESCRIPTION
ModuleNotFoundError: No module named 'jsonschema'