### PR TITLE
add_webhook_args

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -44,3 +44,14 @@ class netpalm_testhelper:
             return result
         except Exception as e:
             return e
+
+    def post_and_check_many(self, url, payload):
+        try:
+            r = requests.post('http://'+self.ip+':'+str(self.port)+url, json=payload, headers=self.headers)
+            result = []
+            for task in r.json()["data"]:
+                res = self.poll_task(task["data"]["data"]["task_id"])
+                result.append(res)
+            return result
+        except Exception as e:
+            return e

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -3,3 +3,4 @@ markers =
     getconfig: gets config (deselect with '-m "not getconfig"')
     setconfig: sets config (deselect with '-m "not setconfig"')
     script: exec script (deselect with '-m "not script"')
+    service: exec service (deselect with '-m "not script"')

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,72 @@
+import pytest
+import requests
+import random
+from tests.helper import netpalm_testhelper
+
+helper = netpalm_testhelper()
+
+@pytest.mark.service
+def test_prepare_vlan_service_environment():
+    pl = {
+        "operation": "delete",
+        "args":{
+            "hosts":["10.0.2.25","10.0.2.23"],
+            "username":"admin",
+            "password":"admin"
+        },
+        "queue_strategy": "fifo"
+    }
+    res = helper.post_and_check_many('/service/vlan_service',pl)
+    if res:
+        assert True
+        
+@pytest.mark.service
+def test_create_vlan_service():
+    pl = {
+        "operation": "create",
+        "args":{
+            "hosts":["10.0.2.25","10.0.2.23"],
+            "username":"admin",
+            "password":"admin"
+        },
+        "queue_strategy": "fifo"
+    }
+    res = helper.post_and_check_many('/service/vlan_service',pl)
+    if "+int vlan 99" in res[0]["changes"][0] and "+int vlan 99" in res[1]["changes"][0]:
+        assert True
+    else:
+        assert False
+
+@pytest.mark.service
+def test_retrieve_vlan_service():
+    pl = {
+        "operation": "retrieve",
+        "args":{
+            "hosts":["10.0.2.25","10.0.2.23"],
+            "username":"admin",
+            "password":"admin"
+        },
+        "queue_strategy": "fifo"
+    }
+    res = helper.post_and_check_many('/service/vlan_service',pl)
+    if res[0]["show int vlan 99"][0]["interface"] == "Vlan99" and res[1]["show int vlan 99"][0]["interface"] == "Vlan99":
+        assert True
+    else:
+        assert False
+
+@pytest.mark.service
+def test_delete_vlan_service():
+    pl = {
+        "operation": "delete",
+        "args":{
+            "hosts":["10.0.2.25","10.0.2.23"],
+            "username":"admin",
+            "password":"admin"
+        },
+        "queue_strategy": "fifo"
+    }
+    res = helper.post_and_check_many('/service/vlan_service',pl)
+    if "-no int vlan 99" in res[0]["changes"][0] and "-no int vlan 99" in res[1]["changes"][0]:
+        assert True
+    else:
+        assert False


### PR DESCRIPTION
- Adds support for arguments in webhooks
- Tidy's up plugins into packages
 -  calls (async tasks)
 - drivers (transport drivers netmiko napalm ncclient etc)
 - extensibles (packages that support extending by the user, eg. custom scripts, j2 templates, service templates, custom webhooks)
 - management (boring jobs such as adding and removing j2/textfsm templates)