### PR TITLE
reorder dockerfiles for much faster builds

### DIFF
--- a/netpalm_controller_dockerfile
+++ b/netpalm_controller_dockerfile
@@ -2,9 +2,10 @@ FROM python:3.8
 WORKDIR /usr/local/lib/python3.8/site-packages
 RUN git clone https://github.com/networktocode/ntc-templates.git
 RUN mv ntc-templates ntc_templates
+RUN pip3 install --upgrade pip
+ADD requirements.txt /code/
+RUN pip3 install -r /code/requirements.txt
 ADD . /code
 WORKDIR /code
-RUN pip3 install --upgrade pip
-RUN pip3 install -r requirements.txt
 RUN ln -sf /usr/local/lib/python3.8/site-packages/ntc_templates/templates/ backend/plugins/extensibles/ntc-templates
 CMD gunicorn -c gunicorn.conf.py netpalm_controller:app

--- a/netpalm_fifo_worker_dockerfile
+++ b/netpalm_fifo_worker_dockerfile
@@ -4,7 +4,7 @@ RUN git clone https://github.com/networktocode/ntc-templates.git
 RUN mv ntc-templates ntc_templates
 RUN pip3 install --upgrade pip
 ADD requirements.txt /code/
-RUN pip3 install -r /code/requirements.txt
+RUN pip3 install -r /code/worker_requirements.txt
 ADD . /code
 WORKDIR /code
 RUN ln -sf /usr/local/lib/python3.8/site-packages/ntc_templates/templates/ backend/plugins/extensibles/ntc-templates

--- a/netpalm_fifo_worker_dockerfile
+++ b/netpalm_fifo_worker_dockerfile
@@ -3,7 +3,7 @@ WORKDIR /usr/local/lib/python3.8/site-packages
 RUN git clone https://github.com/networktocode/ntc-templates.git
 RUN mv ntc-templates ntc_templates
 RUN pip3 install --upgrade pip
-ADD requirements.txt /code/
+ADD worker_requirements.txt /code/
 RUN pip3 install -r /code/worker_requirements.txt
 ADD . /code
 WORKDIR /code

--- a/netpalm_fifo_worker_dockerfile
+++ b/netpalm_fifo_worker_dockerfile
@@ -2,9 +2,10 @@ FROM python:3.8
 WORKDIR /usr/local/lib/python3.8/site-packages
 RUN git clone https://github.com/networktocode/ntc-templates.git
 RUN mv ntc-templates ntc_templates
+RUN pip3 install --upgrade pip
+ADD requirements.txt /code/
+RUN pip3 install -r /code/requirements.txt
 ADD . /code
 WORKDIR /code
-RUN pip3 install --upgrade pip
-RUN pip3 install -r worker_requirements.txt
 RUN ln -sf /usr/local/lib/python3.8/site-packages/ntc_templates/templates/ backend/plugins/extensibles/ntc-templates
 CMD python3 netpalm_fifo_worker.py

--- a/netpalm_pinned_worker_dockerfile
+++ b/netpalm_pinned_worker_dockerfile
@@ -2,9 +2,10 @@ FROM python:3.8
 WORKDIR /usr/local/lib/python3.8/site-packages
 RUN git clone https://github.com/networktocode/ntc-templates.git
 RUN mv ntc-templates ntc_templates
+RUN pip3 install --upgrade pip
+ADD requirements.txt /code/
+RUN pip3 install -r /code/requirements.txt
 ADD . /code
 WORKDIR /code
-RUN pip3 install --upgrade pip
-RUN pip3 install -r worker_requirements.txt
 RUN ln -sf /usr/local/lib/python3.8/site-packages/ntc_templates/templates/ backend/plugins/extensibles/ntc-templates
 CMD python3 netpalm_pinned_worker.py

--- a/netpalm_pinned_worker_dockerfile
+++ b/netpalm_pinned_worker_dockerfile
@@ -4,7 +4,7 @@ RUN git clone https://github.com/networktocode/ntc-templates.git
 RUN mv ntc-templates ntc_templates
 RUN pip3 install --upgrade pip
 ADD requirements.txt /code/
-RUN pip3 install -r /code/requirements.txt
+RUN pip3 install -r /code/worker_requirements.txt
 ADD . /code
 WORKDIR /code
 RUN ln -sf /usr/local/lib/python3.8/site-packages/ntc_templates/templates/ backend/plugins/extensibles/ntc-templates

--- a/netpalm_pinned_worker_dockerfile
+++ b/netpalm_pinned_worker_dockerfile
@@ -3,7 +3,7 @@ WORKDIR /usr/local/lib/python3.8/site-packages
 RUN git clone https://github.com/networktocode/ntc-templates.git
 RUN mv ntc-templates ntc_templates
 RUN pip3 install --upgrade pip
-ADD requirements.txt /code/
+ADD worker_requirements.txt /code/
 RUN pip3 install -r /code/worker_requirements.txt
 ADD . /code
 WORKDIR /code


### PR DESCRIPTION
Handling the requirements.txt before adding the rest of the code makes maximum use of the docker cache, ensuring you're not re-downloading all your dependencies every time you update the code.  Makes using docker for testing much faster.