### PR TITLE
Add Environment Variable Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 backend/plugins/ntc-templates/
 *.pyc
 backend/plugins/ntc-templates
+.idea

--- a/backend/core/confload/confload.py
+++ b/backend/core/confload/confload.py
@@ -1,37 +1,60 @@
 import json
+import os
 
-class config:
-    
-    def __init__(self):
-        with open("config.json") as json_file:
+
+DEFAULT_FILENAME = "config.json"
+
+
+class Config:
+    def __init__(self, config_filename=None):
+        if config_filename is None:
+            config_filename = DEFAULT_FILENAME
+
+        with open(config_filename) as json_file:
             data = json.load(json_file)
-            self.listen_ip = data["listen_ip"]
-            self.listen_port = data["listen_port"]
-            self.netpalm_container_name = data["netpalm_container_name"]
-            self.api_key = data["api_key"]
-            self.api_key_name = data["api_key_name"]
-            self.cookie_domain = data["cookie_domain"]
-            self.redis_task_ttl = data["redis_task_ttl"]
-            self.redis_server = data["redis_server"]
-            self.redis_port = data["redis_port"]
-            self.redis_key = data["redis_key"]
-            self.redis_core_q = data["redis_core_q"]
-            self.redis_fifo_q = data["redis_fifo_q"]
-            self.redis_queue_store = data["redis_queue_store"]
-            self.fifo_process_per_node = data["fifo_process_per_node"]
-            self.pinned_process_per_node = data["pinned_process_per_node"]
-            self.redis_task_timeout = data["redis_task_timeout"]
-            self.txtfsm_index_file = data["txtfsm_index_file"]
-            self.txtfsm_template_server = data["txtfsm_template_server"]
-            self.custom_scripts = data["custom_scripts"]
-            self.jinja2_config_templates = data["jinja2_config_templates"]
-            self.jinja2_service_templates = data["jinja2_service_templates"]
-            self.self_api_call_timeout = data["self_api_call_timeout"]
-            self.default_webhook_url = data["default_webhook_url"]
-            self.default_webhook_ssl_verify = data["default_webhook_ssl_verify"]
-            self.default_webhook_timeout = data["default_webhook_timeout"]
-            self.default_webhook_name = data["default_webhook_name"]
-            self.default_webhook_headers = data["default_webhook_headers"]
-            self.custom_webhooks = data["custom_webhooks"]
-            self.webhook_jinja2_templates = data["webhook_jinja2_templates"]
 
+        self.listen_ip = data["listen_ip"]
+        self.listen_port = data["listen_port"]
+        self.netpalm_container_name = data["netpalm_container_name"]
+        self.api_key = data["api_key"]
+        self.api_key_name = data["api_key_name"]
+        self.cookie_domain = data["cookie_domain"]
+        self.redis_task_ttl = data["redis_task_ttl"]
+        self.redis_server = data["redis_server"]
+        self.redis_port = data["redis_port"]
+        self.redis_key = data["redis_key"]
+        self.redis_core_q = data["redis_core_q"]
+        self.redis_fifo_q = data["redis_fifo_q"]
+        self.redis_queue_store = data["redis_queue_store"]
+        self.fifo_process_per_node = data["fifo_process_per_node"]
+        self.pinned_process_per_node = data["pinned_process_per_node"]
+        self.redis_task_timeout = data["redis_task_timeout"]
+        self.txtfsm_index_file = data["txtfsm_index_file"]
+        self.txtfsm_template_server = data["txtfsm_template_server"]
+        self.custom_scripts = data["custom_scripts"]
+        self.jinja2_config_templates = data["jinja2_config_templates"]
+        self.jinja2_service_templates = data["jinja2_service_templates"]
+        self.self_api_call_timeout = data["self_api_call_timeout"]
+        self.default_webhook_url = data["default_webhook_url"]
+        self.default_webhook_ssl_verify = data["default_webhook_ssl_verify"]
+        self.default_webhook_timeout = data["default_webhook_timeout"]
+        self.default_webhook_name = data["default_webhook_name"]
+        self.default_webhook_headers = data["default_webhook_headers"]
+        self.custom_webhooks = data["custom_webhooks"]
+        self.webhook_jinja2_templates = data["webhook_jinja2_templates"]
+
+        for key in self.__dict__:  # Check for environment variables
+            envvar_key = f'NETPALM_{key.upper()}'
+            if value := os.getenv(envvar_key):
+                setattr(self, key, value)
+
+    def __call__(self):
+        return self
+
+
+# this indirection helps w/ testing, also compatibility with existing code that uses `config().attribute`
+def initialize_config():
+    return Config(os.getenv('NETPALM_CONFIG'))
+
+
+config = initialize_config()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
             dockerfile: ./netpalm_controller_dockerfile
         environment:
             - NET_TEXTFSM=/usr/local/lib/python3.8/site-packages/ntc_templates/templates/
+            - NETPALM_CONFIG=config.json
         ports:
             - "9000:9000"
         networks:
@@ -19,6 +20,7 @@ services:
             dockerfile: ./netpalm_pinned_worker_dockerfile
         environment:
             - NET_TEXTFSM=/usr/local/lib/python3.8/site-packages/ntc_templates/templates/
+            - NETPALM_CONFIG=config.json
         depends_on:
             - netpalm-controller
         networks:
@@ -30,6 +32,7 @@ services:
             dockerfile: ./netpalm_fifo_worker_dockerfile
         environment:
             - NET_TEXTFSM=/usr/local/lib/python3.8/site-packages/ntc_templates/templates/
+            - NETPALM_CONFIG=config.json
         depends_on:
             - netpalm-controller
         networks:

--- a/tests/test_confload.py
+++ b/tests/test_confload.py
@@ -1,0 +1,42 @@
+import os
+from pathlib import Path
+import pytest
+
+CONFIG_FILENAME = "./config.json"
+ACTUAL_CONFIG_PATH = Path(CONFIG_FILENAME).absolute()
+
+if not ACTUAL_CONFIG_PATH.exists():
+    ACTUAL_CONFIG_PATH = ACTUAL_CONFIG_PATH.parent.parent / CONFIG_FILENAME  # try ../config.json
+    if not ACTUAL_CONFIG_PATH.exists():
+        raise FileNotFoundError(f'Can\'t run confload tests without finding config.json, '
+                                f'tried looking in {ACTUAL_CONFIG_PATH}')
+
+
+os.environ["NETPALM_CONFIG"] = str(ACTUAL_CONFIG_PATH)
+from backend.core.confload import confload
+
+
+def test_netpalm_config_honors_envvar():
+    with pytest.raises(FileNotFoundError):
+        config = confload.Config("DOES NOT EXIST.json")
+
+    with pytest.raises(FileNotFoundError):
+        os.environ["NETPALM_CONFIG"] = "DOES NOT EXIST.JSON"
+        config = confload.initialize_config()
+
+    with pytest.raises(FileNotFoundError):  # this depends on the fact that you're running pytest from the tests directory
+        del os.environ["NETPALM_CONFIG"]
+        config = confload.initialize_config()
+
+    config = confload.Config(ACTUAL_CONFIG_PATH)
+    os.environ["NETPALM_CONFIG"] = str(ACTUAL_CONFIG_PATH)
+    config = confload.initialize_config()
+
+
+def test_netpalm_config_value_precedence():
+    file_config = confload.Config(ACTUAL_CONFIG_PATH)
+
+    os.environ['NETPALM_REDIS_SERVER'] = '123.COM'
+    envvar_config = confload.Config(ACTUAL_CONFIG_PATH)
+    assert file_config.redis_key == envvar_config.redis_key
+    assert envvar_config.redis_server == '123.COM'


### PR DESCRIPTION
NOTE:  the way the `confload.config()` object was used before caused `confload.config.__init__()` to be called every time a value was retrieved, which caused the JSON to be read from disk every time as well.  I reorganized it so that `confload.Config` is the class, and `confload.config` is an instance of that class, so `confload.Config.__init__()` is only ran once now.  The most reasonable way to access the attributes now would be `config.attribute`, but I added a `__call__()` method that just returns `self` so the object can still be used like `config().attribute`.  Removing the parens from all of those existing calls will slightly improve performance.

Environment Variables:
NETPALM_CONFIG: specifies config.json location

Also nearly all other config parameters with the form
NETPALM_<config.json key> for example 'redis_server' becomes
'NETPALM_REDIS_SERVER'

Note: Doesn't work for values used outside of Netpalm itself
(e.g. gunicorn uses 'listen_ip' and 'listen_port')