### PR TITLE
Use 'slim' dockerfiles as source

### DIFF
--- a/netpalm_controller_dockerfile
+++ b/netpalm_controller_dockerfile
@@ -1,5 +1,7 @@
-FROM python:3.8
+FROM python:3.8-slim
 WORKDIR /usr/local/lib/python3.8/site-packages
+RUN apt-get update
+RUN apt-get install -y git
 RUN git clone https://github.com/networktocode/ntc-templates.git
 RUN mv ntc-templates ntc_templates
 RUN pip3 install --upgrade pip

--- a/netpalm_fifo_worker_dockerfile
+++ b/netpalm_fifo_worker_dockerfile
@@ -1,5 +1,7 @@
-FROM python:3.8
+FROM python:3.8-slim
 WORKDIR /usr/local/lib/python3.8/site-packages
+RUN apt-get update
+RUN apt-get install -y git
 RUN git clone https://github.com/networktocode/ntc-templates.git
 RUN mv ntc-templates ntc_templates
 RUN pip3 install --upgrade pip

--- a/netpalm_pinned_worker_dockerfile
+++ b/netpalm_pinned_worker_dockerfile
@@ -1,5 +1,7 @@
-FROM python:3.8
+FROM python:3.8-slim
 WORKDIR /usr/local/lib/python3.8/site-packages
+RUN apt-get update
+RUN apt-get install -y git
 RUN git clone https://github.com/networktocode/ntc-templates.git
 RUN mv ntc-templates ntc_templates
 RUN pip3 install --upgrade pip


### PR DESCRIPTION
This results in about 45% reduction in final image size for me (786MB vs 1.45GB).  Faster to boot, build, push/pull to container repos, etc.

Basic trade off is less included utilities.  Missing things like 'git' by default, but includes everything else commonly needed to build python libraries.  Missing packages can always be pulled w/ `apt-get` as done here w/ git.

```
PS C:\projects\netpalm> docker image ls
REPOSITORY                       TAG                 IMAGE ID            CREATED             SIZE
netpalm_controller_slim_buster   latest              eee3a9e19b97        20 hours ago        786MB
netpalm_controller_base          latest              851aa08ae16e        20 hours ago        1.45GB
netpalm_netpalm-worker-pinned    latest              ff77297d58af        20 hours ago        1.42GB
netpalm_netpalm-worker-fifo      latest              3cdd3cb6c4d8        20 hours ago        1.42GB
netpalm_netpalm-controller       latest              29be0ff01dfb        20 hours ago        1.45GB
```