### PR TITLE
expose redis task result TTL as config

### DIFF
--- a/backend/core/confload/confload.py
+++ b/backend/core/confload/confload.py
@@ -30,6 +30,7 @@ class Config:
         self.api_key_name = data["api_key_name"]
         self.cookie_domain = data["cookie_domain"]
         self.redis_task_ttl = data["redis_task_ttl"]
+        self.redis_task_result_ttl = data["redis_task_result_ttl"]
         self.redis_server = data["redis_server"]
         self.redis_port = data["redis_port"]
         self.redis_key = data["redis_key"]

--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
     "gunicorn_workers": 3,
     "redis_task_ttl": 500,
     "redis_task_timeout": 500,
+    "redis_task_result_ttl": 500,
     "redis_server": "redis",
     "redis_port": 6379,
     "redis_key": "Red1zp4ww0rd_",


### PR DESCRIPTION
If concurrency isn't handled well in calling code sometimes it can take longer than 500s to pull a result.  "just keep the result available longer" isn't a great solution to that, but it's a knob worth having in dire circumstances :) 