### PR TITLE
Sync extensibles

### DIFF
--- a/backend/core/confload/confload.py
+++ b/backend/core/confload/confload.py
@@ -42,6 +42,7 @@ class Config:
         self.redis_cache_enabled = data["redis_cache_enabled"]
         self.redis_cache_default_timeout = data["redis_cache_default_timeout"]
         self.redis_cache_key_prefix = data["redis_cache_key_prefix"]
+        self.redis_update_log = data["redis_update_log"]
         self.fifo_process_per_node = data["fifo_process_per_node"]
         self.pinned_process_per_node = data["pinned_process_per_node"]
         self.redis_task_timeout = data["redis_task_timeout"]

--- a/backend/core/models/models.py
+++ b/backend/core/models/models.py
@@ -175,10 +175,16 @@ class GetConfig(BaseModel):
         }
 
 
+class TFSMPushTemplateModel(BaseModel):
+    driver: str
+    command: str
+    template_text: str
+
+
 class TemplateAdd(BaseModel):
-    key: str = None
-    driver: str = None
-    command: str = None
+    key: str
+    driver: str
+    command: str
 
 
 class TemplateRemove(BaseModel):

--- a/backend/core/models/transaction_log.py
+++ b/backend/core/models/transaction_log.py
@@ -1,0 +1,43 @@
+from enum import Enum
+from typing import Union, Literal
+
+from pydantic import BaseModel
+
+
+class TransactionLogEntryType(str, Enum):
+    tfsm_pull = "TFSM_PULL"
+    tfsm_delete = "TFSM_DELETE"
+    echo = "ECHO"
+    init = "INITIALIZE"
+
+
+class EchoModel(BaseModel):
+    msg: str
+
+
+class TFSMPullTemplateModel(BaseModel):
+    key: str
+    driver: str
+    command: str
+
+
+class TFSMDeleteTemplateModel(BaseModel):
+    fsm_template: str
+
+
+class InitEntryModel(BaseModel):
+    init: Literal[True]  # only here to stop model from greedily matching literally any input
+
+
+extn_update_types = {
+    TransactionLogEntryType.tfsm_pull: TFSMPullTemplateModel,
+    TransactionLogEntryType.tfsm_delete: TFSMDeleteTemplateModel,
+    TransactionLogEntryType.init: InitEntryModel,
+    TransactionLogEntryType.echo: EchoModel
+}
+
+
+class TransactionLogEntryModel(BaseModel):
+    seq: int
+    type: TransactionLogEntryType
+    data: Union[TFSMPullTemplateModel, TFSMDeleteTemplateModel, EchoModel, InitEntryModel]

--- a/backend/core/models/transaction_log.py
+++ b/backend/core/models/transaction_log.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 class TransactionLogEntryType(str, Enum):
     tfsm_pull = "TFSM_PULL"
     tfsm_delete = "TFSM_DELETE"
+    tfsm_push = "TFSM_PUSH"
     echo = "ECHO"
     init = "INITIALIZE"
 
@@ -21,6 +22,12 @@ class TFSMPullTemplateModel(BaseModel):
     command: str
 
 
+class TFSMPushTemplateModel(BaseModel):
+    driver: str
+    command: str
+    template_text: str
+
+
 class TFSMDeleteTemplateModel(BaseModel):
     fsm_template: str
 
@@ -32,6 +39,7 @@ class InitEntryModel(BaseModel):
 extn_update_types = {
     TransactionLogEntryType.tfsm_pull: TFSMPullTemplateModel,
     TransactionLogEntryType.tfsm_delete: TFSMDeleteTemplateModel,
+    TransactionLogEntryType.tfsm_push: TFSMPushTemplateModel,
     TransactionLogEntryType.init: InitEntryModel,
     TransactionLogEntryType.echo: EchoModel
 }
@@ -40,4 +48,4 @@ extn_update_types = {
 class TransactionLogEntryModel(BaseModel):
     seq: int
     type: TransactionLogEntryType
-    data: Union[TFSMPullTemplateModel, TFSMDeleteTemplateModel, EchoModel, InitEntryModel]
+    data: Union[TFSMPullTemplateModel, TFSMDeleteTemplateModel, TFSMPushTemplateModel, EchoModel, InitEntryModel]

--- a/backend/core/routes/routes.py
+++ b/backend/core/routes/routes.py
@@ -1,29 +1,27 @@
-#load plugins
-from backend.plugins.calls.getconfig.exec_command import exec_command
-from backend.plugins.calls.setconfig.exec_config import exec_config
-from backend.plugins.calls.service.service import render_service
+# load plugins
 from backend.plugins.calls.dryrun.dryrun import dryrun
+from backend.plugins.calls.getconfig.exec_command import exec_command
 from backend.plugins.calls.scriptrunner.script import script_exec
-
-from backend.plugins.utilities.textfsm.template import gettemplate
-from backend.plugins.utilities.textfsm.template import addtemplate
-from backend.plugins.utilities.textfsm.template import removetemplate
+from backend.plugins.calls.service.service import render_service
+from backend.plugins.calls.setconfig.exec_config import exec_config
 from backend.plugins.utilities.jinja2.j2 import j2gettemplate
 from backend.plugins.utilities.jinja2.j2 import render_j2template
 from backend.plugins.utilities.ls.ls import list_files
-
-
+from backend.plugins.utilities.textfsm.template import listtemplates, pushtemplate, addtemplate, removetemplate, \
+    gettemplate
 
 routes = {
-    "getconfig":exec_command,
-    "setconfig":exec_config,
-    "gettemplate": gettemplate,
+    "getconfig": exec_command,
+    "setconfig": exec_config,
+    "listtemplates": listtemplates,
+    "gettemplate": gettemplate,  # this is entirely unused now I think.
     "addtemplate": addtemplate,
+    "pushtemplate": pushtemplate,
     "removetemplate": removetemplate,
     "ls": list_files,
     "script": script_exec,
-    "j2gettemplate":j2gettemplate,
-    "render_j2template":render_j2template,
-    "render_service":render_service,
-    "dryrun":dryrun
-    }
+    "j2gettemplate": j2gettemplate,
+    "render_j2template": render_j2template,
+    "render_service": render_service,
+    "dryrun": dryrun
+}

--- a/config.json
+++ b/config.json
@@ -19,6 +19,7 @@
     "redis_cache_enabled": true,
     "redis_cache_default_timeout": 300,
     "redis_cache_key_prefix": "NETPALM_RESULT_CACHE",
+    "redis_update_log": "netpalm_extensibles_update_log",
     "pinned_process_per_node": 50,
     "fifo_process_per_node": 10,
     "txtfsm_index_file": "backend/plugins/extensibles/ntc-templates/index",

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ aiofiles
 pyyaml
 cachelib
 python-redis-lock
+filelock

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pytest-timeout
 aiofiles
 pyyaml
 cachelib
+python-redis-lock

--- a/routers/route_utils.py
+++ b/routers/route_utils.py
@@ -208,6 +208,7 @@ def error_handle_w_cache(f):
 
 
 def add_transaction_log_entry(entry_type: TransactionLogEntryType, data: Dict):
+    log.debug(f"Adding {entry_type}: {data}")
     item_dict = {
         "type": entry_type,
         "data": data

--- a/routers/route_utils.py
+++ b/routers/route_utils.py
@@ -1,32 +1,59 @@
 """netpalm/routers/utils.py  Utility functions/classes for API routers"""
+import asyncio
 import hashlib
+import json
+import logging
+from contextlib import contextmanager
 from copy import deepcopy
+from enum import Enum
 from functools import wraps
 from itertools import chain
-import logging
+from typing import Dict
 
 from fastapi import HTTPException
 from pydantic import BaseModel
-from enum import Enum
 
+from backend.core.models.transaction_log import TransactionLogEntryType
 from backend.core.redis import reds
 
 log = logging.getLogger(__name__)
 
 
-def http_error_handler(f):
-    """catch all errors, log and raise an HTTPException"""
+class SyncAsyncDecoratorFactory:
+    """Courtesy of StackOverflow & Github user https://gist.github.com/anatoly-kussul
+    https://gist.github.com/anatoly-kussul/f2d7444443399e51e2f83a76f112364d/ff1f94b1bd07741ce209cc61832f920adb49aedf"""
 
-    @wraps(f)
-    def wrapper(*args, **kwargs):
+    @contextmanager
+    def wrapper(self, func, *args, **kwargs):
+        yield
+
+    def __call__(self, func):
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            with self.wrapper(func, *args, **kwargs):
+                return func(*args, **kwargs)
+
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            with self.wrapper(func, *args, **kwargs):
+                return await func(*args, **kwargs)
+
+        if asyncio.iscoroutinefunction(func):
+            return async_wrapper
+        else:
+            return sync_wrapper
+
+
+class HttpErrorHandler(SyncAsyncDecoratorFactory):
+    @contextmanager
+    def wrapper(self, *args, **kwargs):
         try:
-            log.debug(f'calling {f.__name__}')
-            return f(*args, **kwargs)
+            yield
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            log.exception(f"{e}")
+            log.exception(f"Error Log: {e}")
             raise HTTPException(status_code=500, detail=str(e).split("\n"))
-
-    return wrapper
 
 
 def cache_key_from_model(model: BaseModel) -> str:
@@ -115,6 +142,7 @@ def cache_key_from_req_data(req_data: dict, unsafe_logging: bool = False) -> str
 
 
 def poison_host_cache(f):
+    """THIS IS PROBABLY NOT ASYNC SAFE YET"""
     @wraps(f)
     def wrapper(*args, **kwargs):
         model = [
@@ -131,7 +159,8 @@ def poison_host_cache(f):
 
 
 def cacheable_model(f):
-    """Cache results according to global and per-request cache config.
+    """THIS IS PROBABLY NOT ASYNC SAFE YET
+    Cache results according to global and per-request cache config.
     ONLY APPLICABLE TO ROUTES WITH DEFINED MODELS THAT INCLUDE CACHE CONFIG"""
 
     @wraps(f)
@@ -167,10 +196,25 @@ def cacheable_model(f):
 
 
 def error_handle_w_cache(f):
+    """THIS IS PROBABLY NOT ASYNC SAFE YET"""
+
     @wraps(f)
-    @http_error_handler
+    @HttpErrorHandler()
     @cacheable_model
     def wrapper(*args, **kwargs):
         return f(*args, **kwargs)
 
     return wrapper
+
+
+def add_transaction_log_entry(entry_type: TransactionLogEntryType, data: Dict):
+    item_dict = {
+        "type": entry_type,
+        "data": data
+    }
+    reds.extn_update_log.add(item_dict)
+    worker_message = {
+        "type": "process_update_log",
+        "kwargs": {}
+    }
+    reds.send_broadcast(json.dumps(worker_message))

--- a/routers/setconfig.py
+++ b/routers/setconfig.py
@@ -9,7 +9,7 @@ from backend.core.models.netmiko import NetmikoSetConfig
 from backend.core.models.restconf import Restconf
 from backend.core.models.task import Response
 from backend.core.redis import reds
-from routers.route_utils import http_error_handler, poison_host_cache
+from routers.route_utils import HttpErrorHandler, poison_host_cache
 
 router = APIRouter()
 
@@ -25,7 +25,7 @@ def _set_config(setcfg: SetConfig, library: str = None):
 
 # deploy a configuration
 @router.post("/setconfig", response_model=Response, status_code=201)
-@http_error_handler
+@HttpErrorHandler()
 @poison_host_cache
 def set_config(setcfg: SetConfig):
     return _set_config(setcfg)
@@ -33,7 +33,7 @@ def set_config(setcfg: SetConfig):
 
 # dry run a configuration
 @router.post("/setconfig/dry-run", response_model=Response, status_code=201)
-@http_error_handler
+@HttpErrorHandler()
 def set_config_dry_run(setcfg: SetConfig):
     req_data = setcfg.dict()
     r = reds.execute_task(method="dryrun", kwargs=req_data)
@@ -43,7 +43,7 @@ def set_config_dry_run(setcfg: SetConfig):
 
 # deploy a configuration
 @router.post("/setconfig/netmiko", response_model=Response, status_code=201)
-@http_error_handler
+@HttpErrorHandler()
 @poison_host_cache
 def set_config_netmiko(setcfg: NetmikoSetConfig):
     return _set_config(setcfg, library="netmiko")
@@ -51,7 +51,7 @@ def set_config_netmiko(setcfg: NetmikoSetConfig):
 
 # deploy a configuration
 @router.post("/setconfig/napalm", response_model=Response, status_code=201)
-@http_error_handler
+@HttpErrorHandler()
 @poison_host_cache
 def set_config_napalm(setcfg: NapalmSetConfig):
     return _set_config(setcfg, library="napalm")
@@ -59,7 +59,7 @@ def set_config_napalm(setcfg: NapalmSetConfig):
 
 # deploy a configuration
 @router.post("/setconfig/ncclient", response_model=Response, status_code=201)
-@http_error_handler
+@HttpErrorHandler()
 @poison_host_cache
 def set_config_ncclient(setcfg: NcclientSetConfig):
     return _set_config(setcfg, library="ncclient")
@@ -67,7 +67,7 @@ def set_config_ncclient(setcfg: NcclientSetConfig):
 
 # deploy a configuration
 @router.post("/setconfig/restconf", response_model=Response, status_code=201)
-@http_error_handler
+@HttpErrorHandler()
 @poison_host_cache
 def set_config_restconf(setcfg: Restconf):
     return _set_config(setcfg, library="restconf")

--- a/routers/template.py
+++ b/routers/template.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from fastapi import APIRouter, HTTPException
@@ -8,7 +7,6 @@ from fastapi.encoders import jsonable_encoder
 from backend.core.models.models import TemplateRemove, TemplateAdd
 from backend.core.models.task import ResponseBasic
 from backend.core.models.transaction_log import TransactionLogEntryType
-from backend.core.redis import reds
 # load routes
 from backend.core.routes.routes import routes
 from routers.route_utils import HttpErrorHandler, add_transaction_log_entry
@@ -19,18 +17,11 @@ router = APIRouter()
 
 # textfsm template routes
 @router.get("/template", response_model=ResponseBasic)
+@HttpErrorHandler()
 async def get_textfsm_template():
-    try:
-        r = routes["gettemplate"]()
-        worker_message = {
-            "type": "get_textfsm_template",
-            "kwargs": {}
-        }
-        reds.send_broadcast(json.dumps(worker_message))
-        resp = jsonable_encoder(r)
-        return resp
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e).split("\n"))
+    r = routes["gettemplate"]()
+    resp = jsonable_encoder(r)
+    return resp
 
 
 @router.post("/template", response_model=ResponseBasic, status_code=201)

--- a/routers/util.py
+++ b/routers/util.py
@@ -9,7 +9,7 @@ from starlette.responses import RedirectResponse
 # load config
 from backend.core.confload.confload import config
 from backend.core.redis import reds
-from routers.route_utils import http_error_handler
+from routers.route_utils import HttpErrorHandler
 
 log = logging.getLogger(__name__)
 router = APIRouter()
@@ -39,7 +39,7 @@ async def ping():
 
 # utility route - flush cache
 @router.delete("/cache")
-@http_error_handler
+@HttpErrorHandler()
 def flush_cache(fail: Optional[bool] = Query(False, title="Fail", description="Fail on purpose")):
     if fail:
         raise RuntimeError(f"Failing on Purpose")
@@ -53,7 +53,7 @@ def flush_cache(fail: Optional[bool] = Query(False, title="Fail", description="F
 
 # utility route - flush cache for single device
 @router.delete("/cache/{cache_key}")
-@http_error_handler
+@HttpErrorHandler()
 def flush_cache_device(
         cache_key: str = Path(...,
                               title="The cache key to invalidate",
@@ -68,7 +68,7 @@ def flush_cache_device(
 
 
 @router.get("/cache")
-@http_error_handler
+@HttpErrorHandler()
 def get_cache():
     log.info(f"Getting cache info")
     keys = reds.cache.keys()
@@ -80,7 +80,7 @@ def get_cache():
 
 
 @router.get("/cache/{cache_key}")
-@http_error_handler
+@HttpErrorHandler()
 def get_cache_item(
         cache_key: str = Path(...,
                               title="The cache key to retrieve",

--- a/tests/test_router_utils.py
+++ b/tests/test_router_utils.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException
 from backend.core.confload import confload
 from backend.core.models.models import GetConfig
 from backend.core.redis import rediz
-from routers.route_utils import cacheable_model, http_error_handler, cache_key_from_req_data, poison_host_cache, \
+from routers.route_utils import cacheable_model, HttpErrorHandler, cache_key_from_req_data, poison_host_cache, \
     serialized_for_hash
 
 pytestmark = pytest.mark.nolab
@@ -100,7 +100,7 @@ def test_http_error_handler_raises():
     with pytest.raises(RuntimeError):
         foo()
 
-    foo = http_error_handler(foo)
+    foo = HttpErrorHandler()(foo)
     log.error(f"\nA small traceback following this message is expected")
     with pytest.raises(HTTPException):
         foo()

--- a/tests/test_update_log.py
+++ b/tests/test_update_log.py
@@ -1,0 +1,109 @@
+from pprint import pprint
+
+import pytest
+import redis_lock
+
+from backend.core.confload.confload import config
+
+pytestmark = pytest.mark.nolab
+
+from backend.core.confload import confload
+from backend.core.redis import reds
+from backend.core.redis.rediz import ExtnUpdateLog, ExtnUpdateLogType, ExtnUpdateLogEntry
+
+
+@pytest.fixture(scope="function")
+def clean_log():
+    config = confload.initialize_config()
+    extn_log = ExtnUpdateLog(reds.base_connection, config.redis_update_log, create=False)
+    extn_log.clear()
+
+
+def test_extensible_update_lock_behavior():
+    lock = reds.extn_update_log.lock
+    assert not lock.locked()
+
+    with lock:  # should work
+        assert lock.locked()
+        with pytest.raises(redis_lock.AlreadyAcquired):
+            with lock:  # should fail
+                pass
+        with pytest.raises(redis_lock.AlreadyAcquired):
+            lock.acquire()
+
+        new_lock = redis_lock.Lock(reds.base_connection, config.redis_update_log)
+        assert not new_lock.acquire(blocking=False)
+
+
+def test_extensible_update_log_creation(clean_log):
+    extn_update_log = reds.extn_update_log
+    assert not extn_update_log.exists
+    extn_update_log.create()
+    assert extn_update_log.exists
+
+    new_log_obj = ExtnUpdateLog(reds.base_connection, reds.extn_update_log.log_name)
+    assert new_log_obj.exists
+
+    assert new_log_obj.get(-1).type is ExtnUpdateLogType.init
+
+
+def test_extensible_update_log_add_fetch(clean_log):
+    extn_update_log = reds.extn_update_log
+    reds.extn_update_log.create(strict=True)
+
+    item_1_dict = {
+        "type": ExtnUpdateLogType.tfsm_pull,
+        "data": {
+            "key": "123_432",
+            "driver": "dell_force10",
+            "command": "show version"
+        }
+    }
+    item_2_dict = {
+        "type": ExtnUpdateLogType.tfsm_pull,
+        "data": {
+            "key": "999_876",
+            "driver": "cisco_ios",
+            "command": "show version"
+        }
+    }
+    item_3_dict = {
+        "type": ExtnUpdateLogType.init,
+        "data": {
+            "init": True
+        }
+    }
+    item_dicts = [item_1_dict, item_2_dict, item_3_dict]
+    items = [ExtnUpdateLogEntry(seq=index, **item_dict)
+             for index, item_dict in enumerate(item_dicts, start=1)]
+
+    pprint(items)
+
+    with pytest.raises(ValueError):  # there can be only 1 init records are only valid at very start
+        extn_update_log.add(items[-1])
+    with pytest.raises(ValueError):
+        extn_update_log.add(items[-1].dict())
+
+    del item_dicts[2]
+    del items[2]  # get rid of item_3
+
+    assert (start_len := len(extn_update_log)) == 1  # should only have the init record now
+
+    for item in items:
+        extn_update_log.add(item)
+
+    new_len = start_len + len(items)
+
+    assert len(extn_update_log) == new_len
+
+    with pytest.raises(IndexError):
+        extn_update_log.get(new_len + 10)
+
+    with pytest.raises(IndexError):
+        _ = extn_update_log[new_len + 10]
+
+    log_items = extn_update_log[1:]
+    assert all(item == log_item for item, log_item in zip(items, log_items))
+
+    for item in extn_update_log:
+        print(item)  # proves the we can iterate over the log like a list

--- a/worker_requirements.txt
+++ b/worker_requirements.txt
@@ -12,3 +12,4 @@ genie
 pydantic
 pyyaml
 cachelib
+python-redis-lock

--- a/worker_requirements.txt
+++ b/worker_requirements.txt
@@ -13,3 +13,4 @@ pydantic
 pyyaml
 cachelib
 python-redis-lock
+filelock


### PR DESCRIPTION
Functional POC of a transaction log for managing changes to extensibles such as TextFSM templates. 

This implementation is only for TFSM templates, but plan is to incorporate other types as well.

This implementation so far is a direct port of the prior code that used the broadcast queue.  That means that the controller receiving the request reaches out to get the template, then adds and entry to the log for other nodes to do the same.  

Intent is to reimplement this so that controller fetches the template, then packages it as an entry in the log directly so others can pull from there without having to reach out to the server themselves.