### PR TITLE
adding option to have docker containers automatically start at boot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
           - "netpalm-network"
       depends_on:
           - redis
+      restart: always
 
     netpalm-worker-pinned:
       build:
@@ -29,6 +30,7 @@ services:
         - redis
       networks:
       - "netpalm-network"
+      restart: always
 
     netpalm-worker-fifo:
       build:
@@ -42,6 +44,7 @@ services:
         - redis
       networks:
       - "netpalm-network"
+      restart: always
 
     redis:
       build:
@@ -49,6 +52,7 @@ services:
         dockerfile: ./netpalm_redis_dockerfile
       networks:
       - "netpalm-network"
+      restart: always
 
 networks:
 


### PR DESCRIPTION
When the docker host reboots the netpalm docker containers don't automatically start unless manually startted. This change would do the following: 
```
Always restart the container if it stops. If it is manually stopped, it is restarted only when Docker daemon restarts or the container itself is manually restarted. 
```

