### PR TITLE
Add `/template/match` route for matching templates.

### DIFF
--- a/netpalm/backend/core/models/models.py
+++ b/netpalm/backend/core/models/models.py
@@ -182,14 +182,28 @@ class TFSMPushTemplateModel(BaseModel):
     template_text: str
 
 
-class TemplateAdd(BaseModel):
+class TFSMTemplateAdd(BaseModel):
     key: str
     driver: str
     command: str
 
 
-class TemplateRemove(BaseModel):
+class TFSMTemplateRemove(BaseModel):
     template: str = None
+
+
+class TFSMTemplateMatch(BaseModel):
+    driver: str
+    command: str
+
+
+class TFSMTemplateMatchResponse(BaseModel):
+    """Data returned from TextFSM Library Index lookup"""
+    Template: str  # this is the filename of the template
+    Hostname: str
+    Platform: str
+    Command: str
+    template_text: str  # this is the actual contents of the template file
 
 
 class GeneralError(BaseModel):


### PR DESCRIPTION
so:

Given driver='cisco_ios' and command='show vl' which template will be matched (if any).  If a template is found, returns the contents.  If none is found return an error.