### PR TITLE
adding uvloop, httptools to netpalm/requirements.txt

### DIFF
--- a/netpalm/requirements.txt
+++ b/netpalm/requirements.txt
@@ -1,5 +1,7 @@
 fastapi
 uvicorn
+uvloop
+httptools
 netmiko
 napalm
 ncclient


### PR DESCRIPTION
netpalm-controller was failing to start on a fresh clone / build

edit: specifically gunicorn was failing to start.