### PR TITLE
netconf-rpc

### DIFF
--- a/netpalm/backend/core/models/ncclient.py
+++ b/netpalm/backend/core/models/ncclient.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from typing import Optional, Union
+from enum import Enum
 
 from pydantic import BaseModel
 
@@ -19,12 +20,36 @@ class NcclientGetConfigArgs(BaseModel):
     render_json: Optional[bool] = None
 
 
+class NcclientGetRpcArgs(BaseModel):
+    rpc: str
+    render_json: Optional[bool] = None
+
+
+class NcclientDeviceDrivers(str):
+    default = "default"
+    hpcomware = "hpcomware"
+    h3c = "h3c"
+    alu = "alu"
+    huaweiyang = "huaweiyang"
+    huawei = "huawei"
+    junos = "junos"
+    csr = "csr"
+    nexus = "nexus"
+    iosxr = "iosxr"
+    iosxe = "iosxe"
+
+
+class NcclientDeviceParams(BaseModel):
+    name: NcclientDeviceDrivers
+
+
 class NcclientConnection(BaseModel):
     host: str
     username: str
     password: str
     port: int
     hostkey_verify: bool
+    device_params: Optional[NcclientDeviceParams] = None
 
 
 class NcclientSetConfig(BaseModel):
@@ -51,7 +76,7 @@ class NcclientSetConfig(BaseModel):
 
 class NcclientGetConfig(BaseModel):
     connection_args: NcclientConnection
-    args: NcclientGetConfigArgs
+    args: Union[NcclientGetConfigArgs, NcclientGetRpcArgs]
     webhook: Optional[Webhook] = None
     queue_strategy: Optional[QueueStrategy] = None
     cache: Optional[CacheConfig] = {}

--- a/netpalm/backend/core/routes/routes.py
+++ b/netpalm/backend/core/routes/routes.py
@@ -14,7 +14,7 @@ routes = {
     "getconfig": exec_command,
     "setconfig": exec_config,
     "listtemplates": listtemplates,
-    "gettemplate": gettemplate,  # this is entirely unused now I think.
+    "gettemplate": gettemplate,  # replace with universal template mgr get_template in future
     "addtemplate": addtemplate,
     "pushtemplate": pushtemplate,
     "removetemplate": removetemplate,
@@ -23,5 +23,5 @@ routes = {
     "j2gettemplate": j2gettemplate,
     "render_j2template": render_j2template,
     "render_service": render_service,
-    "dryrun": dryrun
+    "dryrun": dryrun,
 }

--- a/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
+++ b/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
@@ -1,21 +1,21 @@
 import xmltodict
+import logging
 from ncclient import manager
 
 from netpalm.backend.core.utilities.rediz_meta import write_meta_error
+
+log = logging.getLogger(__name__)
 
 
 class ncclien:
 
     def __init__(self, **kwargs):
-        self.username = kwargs.get("username", False)
-        self.password = kwargs.get("password", False)
-        self.driver = kwargs.get("driver", False)
-        self.host = kwargs.get("host", False)
         self.kwarg = kwargs.get("args", False)
-        self.connection_args = kwargs.get("connection_args", False)     
+        self.connection_args = kwargs.get("connection_args", False)
 
     def connect(self):
         try:
+            log.info(self.connection_args)
             conn = manager.connect(**self.connection_args)
             return conn
         except Exception as e:
@@ -30,7 +30,12 @@ class ncclien:
                 if render_json:
                     del self.kwarg["render_json"]
                     rjsflag = True
-                response = session.get_config(**self.kwarg).data_xml
+                # check whether RPC required
+                if self.kwarg.get("rpc", False):
+                    response = session.rpc(**self.kwarg).data_xml
+                # else a standard get_config method call
+                else:
+                    response = session.get_config(**self.kwarg).data_xml
                 if rjsflag:
                     respdict = xmltodict.parse(response)
                     if respdict:

--- a/netpalm/backend/plugins/utilities/universal_template_mgr/unvrsl.py
+++ b/netpalm/backend/plugins/utilities/universal_template_mgr/unvrsl.py
@@ -40,3 +40,16 @@ class unvrsl:
         except Exception as e:
             error = ResponseBasic(status="error", data={"task_result": {"error": str(e)}}).dict()
             return error
+
+    def get_template(self, payload: Dict[str, str]):
+        try:
+            template_path = self.routing_table[payload["route_type"]]["path"] + payload["name"] + self.routing_table[payload["route_type"]]["extn"]
+            result = None
+            with open(template_path, "r") as file:
+                result = file.read()
+            raw_base = base64.b64encode(result.encode('utf-8'))
+            resultdata = ResponseBasic(status="success", data={"task_result": {"base64_payload": raw_base}}).dict()
+            return resultdata
+        except Exception as e:
+            error = ResponseBasic(status="error", data={"task_result": {"error": str(e)}}).dict()
+            return error

--- a/netpalm/requirements.txt
+++ b/netpalm/requirements.txt
@@ -5,7 +5,7 @@ httptools
 ttp
 netmiko==3.3.2
 napalm
-ncclient
+ncclient==0.6.9
 requests
 redis
 rq

--- a/netpalm/routers/getconfig.py
+++ b/netpalm/routers/getconfig.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 
 def _get_config(getcfg: GetConfig, library: str = None):
-    req_data = getcfg.dict()
+    req_data = getcfg.dict(exclude_none=True)
     if library is not None:
         req_data["library"] = library
     r = reds.execute_task(method="getconfig", kwargs=req_data)

--- a/netpalm/routers/setconfig.py
+++ b/netpalm/routers/setconfig.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 
 def _set_config(setcfg: SetConfig, library: str = None):
-    req_data = setcfg.dict()
+    req_data = setcfg.dict(exclude_none=True)
     if library is not None:
         req_data["library"] = library
     r = reds.execute_task(method="setconfig", kwargs=req_data)
@@ -38,7 +38,7 @@ def set_config(setcfg: SetConfig):
 @router.post("/setconfig/dry-run", response_model=Response, status_code=201)
 @HttpErrorHandler()
 def set_config_dry_run(setcfg: SetConfig):
-    req_data = setcfg.dict()
+    req_data = setcfg.dict(exclude_none=True)
     r = reds.execute_task(method="dryrun", kwargs=req_data)
     resp = jsonable_encoder(r)
     return resp

--- a/netpalm/routers/template.py
+++ b/netpalm/routers/template.py
@@ -121,6 +121,23 @@ async def list_ttp_templates():
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e).split("\n"))
 
+
+# get a specfic template
+@router.get("/ttptemplate/{tmpname}", response_model=ResponseBasic)
+async def return_specific_ttp_template(tmpname: str):
+    try:
+        send_payload = {
+            "route_type": "ttp_templates",
+            "name": tmpname
+        }
+        tmplate_mgr = unvrsl()
+        r = tmplate_mgr.get_template(payload=send_payload)
+        resp = jsonable_encoder(r)
+        return resp
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e).split("\n"))
+
+
 # add j2 config template
 @router.post("/ttptemplate/", response_model=ResponseBasic)
 def add_ttp_template(template: UnivsersalTemplateAdd):
@@ -151,6 +168,21 @@ def remove_ttp_template(template: UnivsersalTemplateRemove):
 async def list_config_j2_templates():
     try:
         r = routes["ls"](fldr="config")
+        resp = jsonable_encoder(r)
+        return resp
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e).split("\n"))
+
+# get a specfic template
+@router.get("/j2template/config/{tmpname}", response_model=ResponseBasic)
+async def return_specific_config_j2_template(tmpname: str):
+    try:
+        send_payload = {
+            "route_type": "j2_config_templates",
+            "name": tmpname
+        }
+        tmplate_mgr = unvrsl()
+        r = tmplate_mgr.get_template(payload=send_payload)
         resp = jsonable_encoder(r)
         return resp
     except Exception as e:
@@ -192,6 +224,21 @@ async def list_service_j2_templates():
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e).split('\n'))
 
+# get a specfic template
+@router.get("/j2template/service/{tmpname}", response_model=ResponseBasic)
+async def return_specific_service_j2_template(tmpname: str):
+    try:
+        send_payload = {
+            "route_type": "j2_service_templates",
+            "name": tmpname
+        }
+        tmplate_mgr = unvrsl()
+        r = tmplate_mgr.get_template(payload=send_payload)
+        resp = jsonable_encoder(r)
+        return resp
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e).split("\n"))
+
 # add j2 service template
 @router.post("/j2template/service/", response_model=ResponseBasic)
 def add_service_j2_templates(template: UnivsersalTemplateAdd):
@@ -227,6 +274,21 @@ async def list_webhook_j2_templates():
         return resp
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e).split('\n'))
+
+# get a specfic template
+@router.get("/j2template/webhook/{tmpname}", response_model=ResponseBasic)
+async def return_specific_webhook_j2_template(tmpname: str):
+    try:
+        send_payload = {
+            "route_type": "j2_webhook_templates",
+            "name": tmpname
+        }
+        tmplate_mgr = unvrsl()
+        r = tmplate_mgr.get_template(payload=send_payload)
+        resp = jsonable_encoder(r)
+        return resp
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e).split("\n"))
 
 # add j2 webhook template
 @router.post("/j2template/webhook/", response_model=ResponseBasic)
@@ -345,6 +407,21 @@ def remove_script_file(template: UnivsersalTemplateRemove):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e).split("\n"))
 
+# get a specfic template
+@router.get("/script/{tmpname}", response_model=ResponseBasic)
+async def return_specific_script_file(tmpname: str):
+    try:
+        send_payload = {
+            "route_type": "custom_scripts",
+            "name": tmpname
+        }
+        tmplate_mgr = unvrsl()
+        r = tmplate_mgr.get_template(payload=send_payload)
+        resp = jsonable_encoder(r)
+        return resp
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e).split("\n"))
+
 # webhook script file
 @router.post("/webhook/add/", response_model=ResponseBasic)
 def add_webhook_script_file(template: UnivsersalTemplateAdd):
@@ -354,6 +431,21 @@ def add_webhook_script_file(template: UnivsersalTemplateAdd):
         add_transaction_log_entry(entry_type=TransactionLogEntryType.unvrsl_tmp_push, data=req_data)
         tmplate_mgr = unvrsl()
         r = tmplate_mgr.add_template(payload=req_data)
+        resp = jsonable_encoder(r)
+        return resp
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e).split("\n"))
+
+# get a specfic template
+@router.get("/webhook/{tmpname}", response_model=ResponseBasic)
+async def return_specific_webhook_script_file(tmpname: str):
+    try:
+        send_payload = {
+            "route_type": "custom_webhooks",
+            "name": tmpname
+        }
+        tmplate_mgr = unvrsl()
+        r = tmplate_mgr.get_template(payload=send_payload)
         resp = jsonable_encoder(r)
         return resp
     except Exception as e:

--- a/netpalm/worker_requirements.txt
+++ b/netpalm/worker_requirements.txt
@@ -1,7 +1,7 @@
 netmiko==3.3.2
 ttp
 napalm
-ncclient
+ncclient==0.6.9
 requests
 redis
 rq


### PR DESCRIPTION
- adds support for netconf RPC
eg ```{
	"connection_args": {
		"host": "packetferret.net",
		"username": "{{device_username}}",
		"password": "{{device_password}}",
		"port": 8309,
		"hostkey_verify": false,
        "device_params": {"name": "junos"}
	},
	"args": {
		"rpc": "<get-software-information></get-software-information>",
        "render_json":true
	},
	"queue_strategy": "fifo"
}```
- adds capability to retrieve templates