### PR TITLE
add puresnmp support

### DIFF
--- a/netpalm/backend/core/models/models.py
+++ b/netpalm/backend/core/models/models.py
@@ -14,6 +14,7 @@ class LibraryName(str, Enum):
     ncclient = "ncclient"
     restconf = "restconf"
     netmiko = "netmiko"
+    puresnmp = "puresnmp"
 
 
 class CheckEnum(str, Enum):

--- a/netpalm/backend/core/models/puresnmp.py
+++ b/netpalm/backend/core/models/puresnmp.py
@@ -1,0 +1,37 @@
+from typing import Optional, Any
+
+from pydantic import BaseModel
+
+from netpalm.backend.core.models.models import CacheConfig
+from netpalm.backend.core.models.models import QueueStrategy
+from netpalm.backend.core.models.models import Webhook
+
+
+class PureSNMPConnectionArgs(BaseModel):
+    host: str
+    community: str
+    port: Optional[int] = None
+    timeout: Optional[int] = None
+
+
+class PureSNMPGetConfig(BaseModel):
+    connection_args: PureSNMPConnectionArgs
+    command: Any
+    webhook: Optional[Webhook] = None
+    queue_strategy: Optional[QueueStrategy] = None
+    cache: Optional[CacheConfig] = {}
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "library": "puresnmp",
+                "connection_args": {
+                    "host": "10.0.2.33",
+                    "community": "test",
+                    "port": 161,
+                    "timeout": 2
+                },
+                "command": [".1.3.6.1.4.1.9.2.1.58.0","1.3.6.1.2.1.1.2.0", "1.3.6.1.2.1.1.3.0"],
+                "queue_strategy": "fifo"
+            }
+        }

--- a/netpalm/backend/plugins/calls/getconfig/exec_command.py
+++ b/netpalm/backend/plugins/calls/getconfig/exec_command.py
@@ -5,6 +5,7 @@ from netpalm.backend.core.utilities.rediz_meta import write_meta_error
 from netpalm.backend.plugins.drivers.napalm.napalm_drvr import naplm
 from netpalm.backend.plugins.drivers.ncclient.ncclient_drvr import ncclien
 from netpalm.backend.plugins.drivers.netmiko.netmiko_drvr import netmko
+from netpalm.backend.plugins.drivers.puresnmp.puresnmp_drvr import pursnmp
 from netpalm.backend.plugins.drivers.restconf.restconf import restconf
 from netpalm.backend.plugins.utilities.webhook.webhook import exec_webhook_func
 
@@ -39,6 +40,11 @@ def exec_command(**kwargs):
                 sesh = napl.connect()
                 result = napl.sendcommand(sesh, commandlst)
                 napl.logout(sesh)
+            elif lib == "puresnmp":
+                snm = pursnmp(**kwargs)
+                sesh = snm.connect()
+                result = snm.sendcommand(sesh, commandlst)
+                snm.logout(sesh)
             elif lib == "ncclient":
                 ncc = ncclien(**kwargs)
                 sesh = ncc.connect()

--- a/netpalm/backend/plugins/drivers/puresnmp/puresnmp_drvr.py
+++ b/netpalm/backend/plugins/drivers/puresnmp/puresnmp_drvr.py
@@ -1,0 +1,47 @@
+from puresnmp import get, set
+
+from netpalm.backend.core.utilities.rediz_meta import write_meta_error
+
+
+class pursnmp:
+
+    def __init__(self, **kwargs):
+        self.connection_args = kwargs.get("connection_args", False)
+        if "port" not in self.connection_args.keys():
+            self.connection_args["port"] = 161
+        if "timeout" not in self.connection_args.keys():
+            self.connection_args["timeout"] = 2
+
+    def connect(self):
+        try:
+            return True
+        except Exception as e:
+            write_meta_error(f"{e}")
+
+    def sendcommand(self, session=False, command=False):
+        try:
+            result = {}
+            for c in command:
+                response = get(
+                               ip=self.connection_args["host"],
+                               community=self.connection_args["community"],
+                               oid=c,
+                               port=self.connection_args["port"],
+                               timeout=self.connection_args["timeout"],
+                               )
+                result[c] = response
+            return result
+        except Exception as e:
+            write_meta_error(f"{e}")
+
+    def config(self, session=False, command=False, dry_run=False):
+        try:
+            return True
+        except Exception as e:
+            write_meta_error(f"{e}")
+
+    def logout(self, session):
+        try:
+            return True
+        except Exception as e:
+            write_meta_error(f"{e}")

--- a/netpalm/backend/plugins/extensibles/custom_webhooks/servicenow_request_item_patch_netpalm_webhook.py
+++ b/netpalm/backend/plugins/extensibles/custom_webhooks/servicenow_request_item_patch_netpalm_webhook.py
@@ -1,0 +1,62 @@
+import json
+import requests
+
+import logging
+from netpalm.backend.core.confload.confload import config
+
+"""
+netpalm webhook for updating a request item state and worknotes
+IMPORTANT NOTES:
+    webook requires a payload as per below
+    "webhook": {
+        "name": "servicenow_request_item_patch",
+        "args": {
+            "username": "admin",
+            "password": "",
+            "sys_id": "5d558ebf07679010430dff4c7c1ed036",
+            "servicenow_instance": "dev98005.service-now.com"
+        }
+    }
+"""
+
+log = logging.getLogger(__name__)
+
+
+def run_webhook(payload=False):
+    try:
+        if payload:
+            log.info(f"run webhook: running servicenow webhook")
+            # set variables for POST
+            password = payload["webhook_args"]["password"]
+            username = payload["webhook_args"]["username"]
+            sys_id = payload["webhook_args"]["sys_id"]
+            servicenow_instance = payload["webhook_args"]["servicenow_instance"]
+            # generate clean payload for snow
+            pl = {}
+            if len(payload["data"]["task_errors"]) > 0:
+                pl["state"] = "4"
+            else:
+                pl["state"] = "3"
+            pl["work_notes"] = json.dumps(payload["data"]["task_result"], indent=3)
+            # convert to json
+            # Prepare requests data
+            headers_val = config.default_webhook_headers
+            verify_val = config.default_webhook_ssl_verify
+            timeout_val = config.default_webhook_timeout
+            # execute request
+            response = requests.request("PATCH", url=f"https://{servicenow_instance}/api/now/table/sc_req_item/{sys_id}",
+                                        headers=headers_val,
+                                        verify=verify_val,
+                                        timeout=timeout_val,
+                                        json=pl,
+                                        auth=(username, password)
+                                        )
+            if str(response.status_code)[:1] != "2":
+                return False
+            else:
+                return True
+        else:
+            return False
+    except Exception as e:
+        log.error(f"run webhook: {e}")
+        return e

--- a/netpalm/requirements.txt
+++ b/netpalm/requirements.txt
@@ -23,4 +23,5 @@ cachelib
 python-redis-lock
 filelock
 jsonpath_ng
-apscheduler
+apscheduler==3.6.3
+puresnmp==1.9.1

--- a/netpalm/routers/getconfig.py
+++ b/netpalm/routers/getconfig.py
@@ -8,6 +8,7 @@ from netpalm.backend.core.models.models import GetConfig
 from netpalm.backend.core.models.napalm import NapalmGetConfig
 from netpalm.backend.core.models.ncclient import NcclientGetConfig
 from netpalm.backend.core.models.netmiko import NetmikoGetConfig
+from netpalm.backend.core.models.puresnmp import PureSNMPGetConfig
 from netpalm.backend.core.models.restconf import Restconf
 from netpalm.backend.core.models.task import Response
 from netpalm.backend.core.redis import reds
@@ -45,6 +46,13 @@ def get_config_netmiko(getcfg: NetmikoGetConfig):
 @error_handle_w_cache
 def get_config_napalm(getcfg: NapalmGetConfig):
     return _get_config(getcfg, library="napalm")
+
+
+# read config
+@router.post("/getconfig/puresnmp", response_model=Response, status_code=201)
+@error_handle_w_cache
+def get_config_puresnmp(getcfg: PureSNMPGetConfig):
+    return _get_config(getcfg, library="puresnmp")
 
 
 # read config

--- a/netpalm/worker_requirements.txt
+++ b/netpalm/worker_requirements.txt
@@ -16,4 +16,5 @@ cachelib
 python-redis-lock
 filelock
 jsonpath_ng
-apscheduler
+apscheduler==3.6.3
+puresnmp===1.9.1


### PR DESCRIPTION
adds SNMP v1/v2 support methods to getconfig

eg.
`{
	"connection_args": {
		"host": "10.0.2.33",
        "community": "test",
        "port": 161,
        "timeout":2
	},
	"command": [".1.3.6.1.4.1.9.2.1.58.0","1.3.6.1.2.1.1.2.0", "1.3.6.1.2.1.1.3.0"],
	"queue_strategy": "fifo"
}`
would return 
`{
    "status": "success",
    "data": {
        "task_id": "857f3aff-8538-4419-9b0d-f385f7842c41",
        "created_on": "2020-11-10 08:57:45.651333",
        "task_queue": "fifo",
        "task_meta": {
            "enqueued_at": "2020-11-10 08:57:45.651629",
            "started_at": "2020-11-10 08:57:45.702677",
            "ended_at": "2020-11-10 08:57:45.736101",
            "enqueued_elapsed_seconds": "0",
            "total_elapsed_seconds": "0"
        },
        "task_status": "finished",
        "task_result": {
            ".1.3.6.1.4.1.9.2.1.58.0": 2,
            "1.3.6.1.2.1.1.2.0": "1.3.6.1.4.1.9.1.110",
            "1.3.6.1.2.1.1.3.0": 2614.7
        },
        "task_errors": []
    }
}`

includes a sample webhook of servicenow integration