### PR TITLE
Add kafka support

### DIFF
--- a/docker-compose-with-kafka.yml
+++ b/docker-compose-with-kafka.yml
@@ -1,0 +1,98 @@
+version: "3.7"
+
+services:
+
+    netpalm-controller:
+      build:
+          context: .
+          dockerfile: ./dockerfiles/netpalm_controller_dockerfile
+      environment:
+          - NET_TEXTFSM=/usr/local/lib/python3.8/site-packages/ntc_templates/templates/
+          - NETPALM_CONFIG=/code/config/config.json
+          - NETPALM_LOG_CONFIG_FILENAME=/code/config/log-config.yml
+      ports:
+          - "9000:9000"
+      networks:
+          - "netpalm-network"
+      depends_on:
+          - redis
+      restart: always
+
+    netpalm-worker-pinned:
+      build:
+          context: .
+          dockerfile: ./dockerfiles/netpalm_pinned_worker_dockerfile
+      environment:
+        - NET_TEXTFSM=/usr/local/lib/python3.8/site-packages/ntc_templates/templates/
+        - NETPALM_CONFIG=/code/config/config.json
+        - NETPALM_LOG_CONFIG_FILENAME=/code/config/log-config.yml
+      depends_on:
+        - redis
+      networks:
+      - "netpalm-network"
+      restart: always
+
+    netpalm-worker-fifo:
+      build:
+          context: .
+          dockerfile: ./dockerfiles/netpalm_fifo_worker_dockerfile
+      environment:
+        - NET_TEXTFSM=/usr/local/lib/python3.8/site-packages/ntc_templates/templates/
+        - NETPALM_CONFIG=/code/config/config.json
+        - NETPALM_LOG_CONFIG_FILENAME=/code/config/log-config.yml
+      depends_on:
+        - redis
+      networks:
+      - "netpalm-network"
+      restart: always
+
+    redis:
+      build:
+        context: .
+        dockerfile: ./dockerfiles/netpalm_redis_dockerfile
+      networks:
+      - "netpalm-network"
+      restart: always
+
+    kafka:
+      image: confluentinc/cp-kafka
+      networks:
+      - "netpalm-network"
+      ports:
+          - "9092:9092" # netpalm container inside docker network will use port 29092
+      restart: always
+      depends_on:
+        - zookeeper
+      environment:
+        - KAFKA_BROKER_ID=1
+        - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+        - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+        - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+        - KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+        - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      volumes:
+        - kafka01:/tmp/kafka-logs
+
+    zookeeper:
+      image: confluentinc/cp-zookeeper
+      networks:
+      - "netpalm-network"
+      environment:
+        - ZOOKEEPER_CLIENT_PORT=2181
+        - ZOOKEEPER_TICK_TIME=2000
+      ports:
+          - "2181:2181"
+      restart: always
+      volumes:
+        - zk01:/var/lib/zookeeper
+
+networks:
+  netpalm-network:
+    name: "netpalm-network"
+
+volumes:
+  kafka01:
+    driver: local
+  zk01:
+    driver: local
+  

--- a/netpalm/backend/plugins/extensibles/custom_webhooks/kafka.py
+++ b/netpalm/backend/plugins/extensibles/custom_webhooks/kafka.py
@@ -12,7 +12,7 @@ netpalm webhook for posting a document directly to an kafka topic
 IMPORTANT NOTES:
     webook requires a payload as per below
     "webhook": {
-        "name": "wrm_kafka_producer_webhook",
+        "name": "kafka",
         "args": {
             "topic": "test",
             "bootstrap_server": "kafka",        # hostname or IP of kafka broker

--- a/netpalm/backend/plugins/extensibles/custom_webhooks/kafka.py
+++ b/netpalm/backend/plugins/extensibles/custom_webhooks/kafka.py
@@ -1,0 +1,81 @@
+import json
+from kafka import KafkaProducer
+import logging
+from pprint import pprint
+
+# from netpalm.backend.core.confload.confload import config
+
+# this is a fairly simple example of a kafka producer webhook capability with netpalm
+
+"""
+netpalm webhook for posting a document directly to an kafka topic
+IMPORTANT NOTES:
+    webook requires a payload as per below
+    "webhook": {
+        "name": "wrm_kafka_producer_webhook",
+        "args": {
+            "topic": "test",
+            "bootstrap_server": "kafka",        # hostname or IP of kafka broker
+            "port": 29092                       # this is default if omitted,
+            "message_format": json              # json - json is default if omitted. allow future options?
+        }
+    }
+"""
+
+log = logging.getLogger(__name__)
+
+DEFAULT_KAFKA_PORT = 29092
+DEFAULT_MESSAGE_FORMAT = "json"
+
+
+def run_webhook(payload=False):
+    try:
+        if payload:
+            log.info(f"run webhook: running kafka webhook")
+            # set variables for Kafka
+            topic = payload["webhook_args"]["topic"]
+            bootstrap_server = payload["webhook_args"]["bootstrap_server"]
+            kafka_port = payload["webhook_args"].get("port", DEFAULT_KAFKA_PORT)
+            msg_format = payload["webhook_args"].get(
+                "message_format", DEFAULT_MESSAGE_FORMAT
+            )
+            del payload["webhook_args"]
+
+            print(f"DEBUG payload:  {payload}")
+
+            data = payload.pop("data")
+            task_result = data.pop("task_result")
+            task_errors = data.pop("task_errors")
+
+            # some debug output for testing
+            print(f"DEBUG task_result:  {task_result}")
+            print(f"DEBUG task_result:  {task_errors}")
+            print()
+            pprint(f"DEBUG data: {data}")
+
+            # pull out certain fields into Kafka message headers as a list of tuples
+            task_id = ("task_id", data.get("task_id").encode("utf-8"))
+            created_on = ("created_on", data.get("created_on").encode("utf-8"))
+            headers = [task_id, created_on]
+
+            print(f"DEBUG headers:  {headers}")
+
+            # NOTE: bootstrap_servers only supports single server at this time, could also be a list
+            if msg_format.lower() == DEFAULT_MESSAGE_FORMAT:
+                # json message format
+                producer = KafkaProducer(
+                    bootstrap_servers=f"{bootstrap_server}:{kafka_port}",
+                    value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+                )
+                print(f"DEBUG - task_result that will be sent to topic: {task_result}")
+                producer.send(topic, task_result, headers=headers)
+
+            else:
+                # didn't specify a valid message format, raise ValueError
+                raise ValueError("invalid message format specified")
+            return True
+        else:
+            return False
+    except Exception as e:
+        log.error(f"Kafka webhook error: {e}")
+        return e

--- a/netpalm/worker_requirements.txt
+++ b/netpalm/worker_requirements.txt
@@ -18,3 +18,4 @@ filelock
 jsonpath_ng
 apscheduler==3.6.3
 puresnmp===1.9.1
+kafka-python


### PR DESCRIPTION
added support for webhook machinery to publish data to kafka topic.  summary of changes:

* added `kafka-python` requirement to workers
* added `kafka.py` as a simple webhook example to publish data
* added a docker-compose file that includes kafka and zookeeper, can be run with `docker-compose -f docker-compose-with-kafka.yml up -d`

