### PR TITLE
Add /getconfig/ncclient/get api endpoint for ncclient.Manager:get() calls 

### DIFF
--- a/netpalm/backend/core/models/ncclient.py
+++ b/netpalm/backend/core/models/ncclient.py
@@ -54,6 +54,11 @@ class NcclientConnection(BaseModel):
     device_params: Optional[NcclientDeviceParams] = None
 
 
+class NcclientGetArgs(BaseModel):
+    filter: str
+    render_json: Optional[bool] = False
+
+
 class NcclientSetConfig(BaseModel):
     connection_args: NcclientConnection
     args: Optional[NcclientSendConfigArgs] = {}
@@ -103,6 +108,38 @@ class NcclientGetConfig(BaseModel):
                 },
                 "args": {
                     "source": "running",
+                    "filter":
+                    "<filter type='subtree'><System xmlns='http://cisco.com/ns/yang/cisco-nx-os-device'></System></filter>",
+                    "render_json": True
+                },
+                "queue_strategy": "fifo",
+                "cache": {
+                    "enabled": True,
+                    "ttl": 300,
+                    "poison": False
+                }
+            }
+        }
+
+
+class NcclientGet(BaseModel):
+    connection_args: NcclientConnection
+    args: NcclientGetArgs
+    queue_strategy: Optional[QueueStrategy] = None
+    cache: Optional[CacheConfig] = {}
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "library": "ncclient",
+                "connection_args": {
+                    "host": "10.0.2.39",
+                    "username": "admin",
+                    "password": "admin",
+                    "port": 830,
+                    "hostkey_verify": False
+                },
+                "args": {
                     "filter":
                     "<filter type='subtree'><System xmlns='http://cisco.com/ns/yang/cisco-nx-os-device'></System></filter>",
                     "render_json": True

--- a/netpalm/backend/core/routes/routes.py
+++ b/netpalm/backend/core/routes/routes.py
@@ -1,6 +1,7 @@
 # load plugins
 from netpalm.backend.plugins.calls.dryrun.dryrun import dryrun
 from netpalm.backend.plugins.calls.getconfig.exec_command import exec_command
+from netpalm.backend.plugins.calls.getconfig.ncclient_get import ncclient_get
 from netpalm.backend.plugins.calls.scriptrunner.script import script_exec
 from netpalm.backend.plugins.calls.service.service import render_service
 from netpalm.backend.plugins.calls.setconfig.exec_config import exec_config
@@ -24,4 +25,5 @@ routes = {
     "render_j2template": render_j2template,
     "render_service": render_service,
     "dryrun": dryrun,
+    "ncclient_get": ncclient_get,
 }

--- a/netpalm/backend/plugins/calls/getconfig/ncclient_get.py
+++ b/netpalm/backend/plugins/calls/getconfig/ncclient_get.py
@@ -1,0 +1,28 @@
+import logging
+
+from netpalm.backend.core.utilities.rediz_meta import write_meta_error
+from netpalm.backend.plugins.drivers.ncclient.ncclient_drvr import ncclien
+
+log = logging.getLogger(__name__)
+
+
+def ncclient_get(**kwargs):
+    """main function for executing getconfig commands to southbound drivers"""
+    log.debug(f'called w/ {kwargs}')
+    lib = kwargs.get("library", False)
+
+    result = False
+
+    try:
+        result = {}
+        if lib == "ncclient":
+            ncc = ncclien(**kwargs)
+            sesh = ncc.connect()
+            result = ncc.getmethod(sesh)
+            ncc.logout(sesh)
+        else:
+            raise NotImplementedError(f"unknown 'library' parameter {lib}")
+    except Exception as e:
+        write_meta_error(f"{e}")
+
+    return result

--- a/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
+++ b/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
@@ -20,6 +20,29 @@ class ncclien:
         except Exception as e:
             write_meta_error(f"{e}")
 
+    def getmethod(self, session=False, command=False):
+        try:
+            result = {}
+            if self.kwarg:
+                rjsflag = False
+                if self.kwarg.get("render_json", False):
+                    del self.kwarg["render_json"]
+                    rjsflag = True
+                response = session.get(**self.kwarg).data_xml
+                if rjsflag:
+                    respdict = xmltodict.parse(response)
+                    if respdict:
+                        result["get_config"] = respdict
+                    else:
+                        write_meta_error("failed to parse response")
+                else:
+                    result["get_config"] = response
+            else:
+                write_meta_error("args are required")
+            return result
+        except Exception as e:
+            write_meta_error(f"{e}")
+
     def getconfig(self, session=False, command=False):
         try:
             result = {}


### PR DESCRIPTION
Certain device types in ncclient don't have an rpc function defined. As a result when calling the `ncclient.Manager:rpc()` method, Exceptions are thrown. This is a work around to resolve that issue.

https://github.com/ncclient/ncclient/blob/v0.6.9/ncclient/manager.py#L256-L272

commit 124da73e0c18721112c5ce0499014d3add0996ef
Author: Ryan Wendt <rwendt@bandwidth.com>
Date:   Tue Dec 1 10:42:24 2020 -0500

    actually import new model

commit af6aa76d9231c3e4624d3277de6f697ff01291b2
Author: Ryan Wendt <rwendt@bandwidth.com>
Date:   Tue Dec 1 10:23:12 2020 -0500

    fixing routers.getconfig

commit cd0e559660e290f925872b95c3d49c30f891e936
Author: Ryan Wendt <rwendt@bandwidth.com>
Date:   Tue Dec 1 09:53:10 2020 -0500

    adding /getconfig/ncclient/get endpoint for ncclient.Manager:get() calls