### PR TITLE
Add target device whitelist

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -50,5 +50,6 @@
   "custom_webhooks": "netpalm/backend/plugins/extensibles/custom_webhooks/",
   "log_config_filename": "config/log-config.yml",
   "apscheduler_num_processes": 1,
-  "apscheduler_num_threads": 5
+  "apscheduler_num_threads": 5,
+  "device_whitelist": []
 }

--- a/netpalm/backend/core/confload/confload.py
+++ b/netpalm/backend/core/confload/confload.py
@@ -6,11 +6,12 @@ from pathlib import Path
 
 import yaml
 
+from netpalm.backend.core.security.whitelist import DeviceWhitelist
+
 try:
     yaml_loader = yaml.CSafeLoader
 except AttributeError:
     yaml_loader = yaml.SafeLoader
-
 
 log = logging.getLogger(__name__)
 DEFAULT_FILENAME = "config/config.json"
@@ -73,6 +74,7 @@ class Config:
         self.ttp_templates = data["ttp_templates"]
         self.apscheduler_num_processes = data["apscheduler_num_processes"]
         self.apscheduler_num_threads = data["apscheduler_num_threads"]
+        self.whitelist = DeviceWhitelist(data.get("device_whitelist"))
 
         #load tls
         try:

--- a/netpalm/backend/core/security/whitelist.py
+++ b/netpalm/backend/core/security/whitelist.py
@@ -1,0 +1,49 @@
+import ipaddress
+from fnmatch import fnmatch
+
+from typing import List
+
+
+class WhiteListRule:
+    """
+    if `definition` is a valid IPv4 or IPv6 Address or network in CIDR format, evaluate candidate
+    hosts as addresses and return if they are in the equivalent network.
+
+    else do unix filesystem-like wildcard matching ('*.foo.com' matches 'a.foo.com' but not 'foo.com' itself)
+    """
+
+    def __init__(self, definition: str):
+        try:
+            self.definition = ipaddress.ip_interface(definition).network
+            self.type = 'ip'
+        except ValueError:
+            self.definition = definition
+            self.type = 'str'
+
+    def match(self, host: str) -> bool:
+        if self.type == 'ip':
+            try:
+                return ipaddress.ip_address(host) in self.definition
+            except ValueError:
+                return False
+
+        return fnmatch(host, self.definition)
+
+
+class DeviceWhitelist:
+    """
+    evaluate rules in order, return True if any match.  If rule list is empty, return True for anything
+    """
+
+    def __init__(self, definition: List[str]):
+        self.definition = definition
+        if self.definition is None:
+            definition = []
+
+        self.rules = [WhiteListRule(rule_definition) for rule_definition in definition]
+
+    def match(self, hostname):
+        if not self.rules:
+            return True
+
+        return any(rule.match(hostname) for rule in self.rules)

--- a/netpalm/backend/core/security/whitelist.py
+++ b/netpalm/backend/core/security/whitelist.py
@@ -15,13 +15,13 @@ class WhiteListRule:
     def __init__(self, definition: str):
         try:
             self.definition = ipaddress.ip_interface(definition).network
-            self.type = 'ip'
+            self.type = "ip"
         except ValueError:
             self.definition = definition
-            self.type = 'str'
+            self.type = "str"
 
     def match(self, host: str) -> bool:
-        if self.type == 'ip':
+        if self.type == "ip":
             try:
                 return ipaddress.ip_address(host) in self.definition
             except ValueError:

--- a/netpalm/routers/getconfig.py
+++ b/netpalm/routers/getconfig.py
@@ -13,7 +13,7 @@ from netpalm.backend.core.models.puresnmp import PureSNMPGetConfig
 from netpalm.backend.core.models.restconf import Restconf
 from netpalm.backend.core.models.task import Response
 from netpalm.backend.core.redis import reds
-from netpalm.routers.route_utils import error_handle_w_cache
+from netpalm.routers.route_utils import error_handle_w_cache, whitelist
 
 log = logging.getLogger(__name__)
 router = APIRouter()
@@ -31,6 +31,7 @@ def _get_config(getcfg: GetConfig, library: str = None):
 # read config
 @router.post("/getconfig", response_model=Response, status_code=201)
 @error_handle_w_cache
+@whitelist
 def get_config(getcfg: GetConfig):
     return _get_config(getcfg)
 
@@ -38,6 +39,7 @@ def get_config(getcfg: GetConfig):
 # read config
 @router.post("/getconfig/netmiko", response_model=Response, status_code=201)
 @error_handle_w_cache
+@whitelist
 def get_config_netmiko(getcfg: NetmikoGetConfig):
     return _get_config(getcfg, library="netmiko")
 
@@ -45,6 +47,7 @@ def get_config_netmiko(getcfg: NetmikoGetConfig):
 # read config
 @router.post("/getconfig/napalm", response_model=Response, status_code=201)
 @error_handle_w_cache
+@whitelist
 def get_config_napalm(getcfg: NapalmGetConfig):
     return _get_config(getcfg, library="napalm")
 
@@ -52,6 +55,7 @@ def get_config_napalm(getcfg: NapalmGetConfig):
 # read config
 @router.post("/getconfig/puresnmp", response_model=Response, status_code=201)
 @error_handle_w_cache
+@whitelist
 def get_config_puresnmp(getcfg: PureSNMPGetConfig):
     return _get_config(getcfg, library="puresnmp")
 
@@ -59,6 +63,7 @@ def get_config_puresnmp(getcfg: PureSNMPGetConfig):
 # read config
 @router.post("/getconfig/ncclient", response_model=Response, status_code=201)
 @error_handle_w_cache
+@whitelist
 def get_config_ncclient(getcfg: NcclientGetConfig):
     return _get_config(getcfg, library="ncclient")
 
@@ -70,6 +75,7 @@ def get_config_ncclient(getcfg: NcclientGetConfig):
              response_model=Response,
              status_code=201)
 @error_handle_w_cache
+@whitelist
 def ncclient_get(getcfg: NcclientGet, library: str = "ncclient"):
     req_data = getcfg.dict(exclude_none=True)
     if library is not None:
@@ -82,5 +88,6 @@ def ncclient_get(getcfg: NcclientGet, library: str = "ncclient"):
 # read config
 @router.post("/getconfig/restconf", response_model=Response, status_code=201)
 @error_handle_w_cache
+@whitelist
 def get_config_restconf(getcfg: Restconf):
     return _get_config(getcfg, library="restconf")

--- a/netpalm/routers/setconfig.py
+++ b/netpalm/routers/setconfig.py
@@ -11,7 +11,7 @@ from netpalm.backend.core.models.netmiko import NetmikoSetConfig
 from netpalm.backend.core.models.restconf import Restconf
 from netpalm.backend.core.models.task import Response
 from netpalm.backend.core.redis import reds
-from netpalm.routers.route_utils import HttpErrorHandler, poison_host_cache
+from netpalm.routers.route_utils import HttpErrorHandler, poison_host_cache, whitelist
 
 log = logging.getLogger(__name__)
 router = APIRouter()
@@ -30,6 +30,7 @@ def _set_config(setcfg: SetConfig, library: str = None):
 @router.post("/setconfig", response_model=Response, status_code=201)
 @HttpErrorHandler()
 @poison_host_cache
+@whitelist
 def set_config(setcfg: SetConfig):
     return _set_config(setcfg)
 
@@ -37,6 +38,7 @@ def set_config(setcfg: SetConfig):
 # dry run a configuration
 @router.post("/setconfig/dry-run", response_model=Response, status_code=201)
 @HttpErrorHandler()
+@whitelist
 def set_config_dry_run(setcfg: SetConfig):
     req_data = setcfg.dict(exclude_none=True)
     r = reds.execute_task(method="dryrun", kwargs=req_data)
@@ -48,6 +50,7 @@ def set_config_dry_run(setcfg: SetConfig):
 @router.post("/setconfig/netmiko", response_model=Response, status_code=201)
 @HttpErrorHandler()
 @poison_host_cache
+@whitelist
 def set_config_netmiko(setcfg: NetmikoSetConfig):
     return _set_config(setcfg, library="netmiko")
 
@@ -56,6 +59,7 @@ def set_config_netmiko(setcfg: NetmikoSetConfig):
 @router.post("/setconfig/napalm", response_model=Response, status_code=201)
 @HttpErrorHandler()
 @poison_host_cache
+@whitelist
 def set_config_napalm(setcfg: NapalmSetConfig):
     return _set_config(setcfg, library="napalm")
 
@@ -64,6 +68,7 @@ def set_config_napalm(setcfg: NapalmSetConfig):
 @router.post("/setconfig/ncclient", response_model=Response, status_code=201)
 @HttpErrorHandler()
 @poison_host_cache
+@whitelist
 def set_config_ncclient(setcfg: NcclientSetConfig):
     return _set_config(setcfg, library="ncclient")
 
@@ -72,5 +77,6 @@ def set_config_ncclient(setcfg: NcclientSetConfig):
 @router.post("/setconfig/restconf", response_model=Response, status_code=201)
 @HttpErrorHandler()
 @poison_host_cache
+@whitelist
 def set_config_restconf(setcfg: Restconf):
     return _set_config(setcfg, library="restconf")

--- a/tests/test_device_whitelist.py
+++ b/tests/test_device_whitelist.py
@@ -20,7 +20,8 @@ log = logging.getLogger(__name__)
         ("10.0.0.*", "10.0.0.1", True),
         ("10.0.0.0/8", "10.0.0.1", True),
         ("10.0.0.0", "10.0.0.1", False),
-        ("10.0.0.1", "10.0.0.1", True)
+        ("10.0.0.1", "10.0.0.1", True),
+        ("2600::1", "2600:0:0:0:0::1", True)
     ]
 )
 def test_whitelist_rule(rule_definition: str, hostname: str, expected: bool):

--- a/tests/test_device_whitelist.py
+++ b/tests/test_device_whitelist.py
@@ -1,0 +1,78 @@
+import logging
+from typing import List, Tuple
+
+import pytest
+
+from netpalm.backend.core.security.whitelist import DeviceWhitelist, WhiteListRule
+
+pytestmark = pytest.mark.whitelist
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    ('rule_definition', 'hostname', 'expected'),
+    [
+        ('*.com', 'foo.com', True),
+        ('*.com', 'bar', False),
+        ('foo.com', 'b.foo.com', False),
+        ('*.com', '10.0.0.1', False),
+        ('10.0.0.*', '10.0.0.1', True),
+        ('10.0.0.0/8', '10.0.0.1', True),
+        ('10.0.0.0', '10.0.0.1', False),
+        ('10.0.0.1', '10.0.0.1', True)
+    ]
+)
+def test_whitelist_rule(rule_definition: str, hostname: str, expected: bool):
+    rule = WhiteListRule(rule_definition)
+    assert rule.match(hostname) == expected
+
+
+@pytest.mark.parametrize(('whitelist_definition', 'tests'), [
+    ([], [
+        ('foo.com', True),
+        ('bar', True),
+        ('10.0.0.1', True),
+        ('172.24.1.1', True)
+    ]),
+    (None, [
+        ('foo.com', True),
+        ('bar', True),
+        ('10.0.0.1', True),
+        ('172.24.1.1', True)
+    ]),
+    ([
+         "*.com"
+     ], [
+         ('foo.com', True),
+         ('a.foo.com', True),
+         ('bar', False),
+         ('10.0.0.1', False),
+         ('172.24.1.1', False)
+     ]),
+    ([
+         "*.foo.com",
+         "bar"
+     ], [
+         ('foo.com', False),
+         ('a.foo.com', True),
+         ('bar', True),
+         ('10.0.0.1', False),
+         ('172.24.1.1', False)
+     ]),
+    ([
+         "10.0.0.0/24"
+     ], [
+         ('foo.com', False),
+         ('a.foo.com', False),
+         ('bar', False),
+         ('10.0.0.1', True),
+         ('172.24.1.1', False)
+     ]),
+])
+def test_device_whitelist(whitelist_definition: List[str], tests: List[Tuple[str, bool]]):
+    dwl = DeviceWhitelist(whitelist_definition)
+    assert dwl.definition == whitelist_definition
+    for hostname, expected in tests:
+        print(f'testing {hostname} expecting {expected}')
+        assert dwl.match(hostname) == expected

--- a/tests/test_device_whitelist.py
+++ b/tests/test_device_whitelist.py
@@ -11,16 +11,16 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize(
-    ('rule_definition', 'hostname', 'expected'),
+    ("rule_definition", "hostname", "expected"),
     [
-        ('*.com', 'foo.com', True),
-        ('*.com', 'bar', False),
-        ('foo.com', 'b.foo.com', False),
-        ('*.com', '10.0.0.1', False),
-        ('10.0.0.*', '10.0.0.1', True),
-        ('10.0.0.0/8', '10.0.0.1', True),
-        ('10.0.0.0', '10.0.0.1', False),
-        ('10.0.0.1', '10.0.0.1', True)
+        ("*.com", "foo.com", True),
+        ("*.com", "bar", False),
+        ("foo.com", "b.foo.com", False),
+        ("*.com", "10.0.0.1", False),
+        ("10.0.0.*", "10.0.0.1", True),
+        ("10.0.0.0/8", "10.0.0.1", True),
+        ("10.0.0.0", "10.0.0.1", False),
+        ("10.0.0.1", "10.0.0.1", True)
     ]
 )
 def test_whitelist_rule(rule_definition: str, hostname: str, expected: bool):
@@ -28,51 +28,51 @@ def test_whitelist_rule(rule_definition: str, hostname: str, expected: bool):
     assert rule.match(hostname) == expected
 
 
-@pytest.mark.parametrize(('whitelist_definition', 'tests'), [
+@pytest.mark.parametrize(("whitelist_definition", "tests"), [
     ([], [
-        ('foo.com', True),
-        ('bar', True),
-        ('10.0.0.1', True),
-        ('172.24.1.1', True)
+        ("foo.com", True),
+        ("bar", True),
+        ("10.0.0.1", True),
+        ("172.24.1.1", True)
     ]),
     (None, [
-        ('foo.com', True),
-        ('bar', True),
-        ('10.0.0.1', True),
-        ('172.24.1.1', True)
+        ("foo.com", True),
+        ("bar", True),
+        ("10.0.0.1", True),
+        ("172.24.1.1", True)
     ]),
     ([
          "*.com"
      ], [
-         ('foo.com', True),
-         ('a.foo.com', True),
-         ('bar', False),
-         ('10.0.0.1', False),
-         ('172.24.1.1', False)
+         ("foo.com", True),
+         ("a.foo.com", True),
+         ("bar", False),
+         ("10.0.0.1", False),
+         ("172.24.1.1", False)
      ]),
     ([
          "*.foo.com",
          "bar"
      ], [
-         ('foo.com', False),
-         ('a.foo.com', True),
-         ('bar', True),
-         ('10.0.0.1', False),
-         ('172.24.1.1', False)
+         ("foo.com", False),
+         ("a.foo.com", True),
+         ("bar", True),
+         ("10.0.0.1", False),
+         ("172.24.1.1", False)
      ]),
     ([
          "10.0.0.0/24"
      ], [
-         ('foo.com', False),
-         ('a.foo.com', False),
-         ('bar', False),
-         ('10.0.0.1', True),
-         ('172.24.1.1', False)
-     ]),
+        ("foo.com", False),
+        ("a.foo.com", False),
+        ("bar", False),
+        ("10.0.0.1", True),
+        ("172.24.1.1", False)
+    ]),
 ])
 def test_device_whitelist(whitelist_definition: List[str], tests: List[Tuple[str, bool]]):
     dwl = DeviceWhitelist(whitelist_definition)
     assert dwl.definition == whitelist_definition
     for hostname, expected in tests:
-        print(f'testing {hostname} expecting {expected}')
+        print(f"testing {hostname} expecting {expected}")
         assert dwl.match(hostname) == expected


### PR DESCRIPTION
adds optional device whitelisting.  

Activated via "device_whitelist" option in `config.json`.  This defaults to empty list which permits everything.  

If there are entries it first tries to evaluate them as IP Addresses or networks (v4 or v6).  This checks for address equality, as well as checking if addresses are a member of a network given (if given in CIDR notation).  

If the given pattern can't be interpreted as an IP address or network, it falls back to simple wildcard matching as used in Unix filesystem.  "\*.foo.com" and "10.\*" match "bar.foo.com" and "10.2.2.asdfadf123" respectively.
