### PR TITLE
bump github action dependency to newer version, make actions use new publicly available cisshgo images

### DIFF
--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -21,7 +21,7 @@ jobs:
       - run: docker pull golang:1.15.0-buster
       - run: docker pull redis:6.0.7-alpine
 
-      - uses: satackey/action-docker-layer-caching@v0.0.8
+      - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:
           key: ci-tests-{hash}

--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -18,7 +18,7 @@ jobs:
       #      - run: docker-compose -f docker-compose.ci.yml build cisgo redis  # don't cache this
 
       - run: docker pull python:3.8-slim
-      - run: docker pull golang:1.15.0-buster
+      - run: docker pull apcela/cisshgo:v0.0.1
       - run: docker pull redis:6.0.7-alpine
 
       - uses: satackey/action-docker-layer-caching@v0.0.11

--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -18,7 +18,7 @@ jobs:
       #      - run: docker-compose -f docker-compose.ci.yml build cisgo redis  # don't cache this
 
       - run: docker pull python:3.8-slim
-      - run: docker pull apcela/cisshgo:v0.0.1
+      - run: docker pull apcela/cisshgo:v0.0.4
       - run: docker pull redis:6.0.7-alpine
 
       - uses: satackey/action-docker-layer-caching@v0.0.11

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
    <br/>
    <p align="center">
    netpalm makes it easy to push and pull state from your apps to your network by providing multiple southbound drivers, abstraction methods and modern northbound  interfaces such as open API3 and REST webhooks.
-   </p>
+   </p> 
    <p align="center" style="align: center;">
       <img src="https://github.com/tbotnz/netpalm/workflows/tests/badge.svg" alt="Tests"/>
       <a href="https://networktocode.slack.com" alt="NTC Slack"><img src="https://img.shields.io/badge/slack-networktocode-orange" alt="NTC Slack" /></a>

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -50,9 +50,7 @@ services:
       - "netpalm-network"
 
   cisgo:
-    build:
-      context: ./dockerfiles
-      dockerfile: cisgo_dockerfile
+    image: apcela/cisshgo:v0.0.1
     networks:
       - "netpalm-network"
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -50,7 +50,7 @@ services:
       - "netpalm-network"
 
   cisgo:
-    image: apcela/cisshgo:v0.0.1
+    image: apcela/cisshgo:v0.0.4
     networks:
       - "netpalm-network"
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -71,9 +71,7 @@ services:
         restart: always
 
     cisgo:
-        build:
-            context: ./dockerfiles
-            dockerfile: cisgo_dockerfile
+        image: apcela/cisshgo:v0.0.1
         #            dockerfile: Dockerfile
         ports:
             - "10005:10005"  # one port just for convenience in case you need to ssh from outside for some reason

--- a/dockerfiles/cisgo_dockerfile
+++ b/dockerfiles/cisgo_dockerfile
@@ -1,6 +1,0 @@
-FROM golang:1.15.0-buster
-ENV GO111MODULE=on
-RUN git clone --depth 1 --branch v0.0.1  https://github.com/tbotnz/cisgo-ios
-WORKDIR /go/cisgo-ios/
-RUN go build cis.go
-CMD /go/cisgo-ios/cis

--- a/tests/test_getconfig_cisgo.py
+++ b/tests/test_getconfig_cisgo.py
@@ -8,7 +8,7 @@ from tests.helper import netpalm_testhelper
 log = logging.getLogger(__name__)
 helper = netpalm_testhelper()
 
-CISGO_DEFAULT_HOSTNAME = "cisgo1000v"
+CISGO_DEFAULT_HOSTNAME = "cisshgo1000v"
 
 
 def cisgo_port_number():


### PR DESCRIPTION
should offer better caching and thus faster test runs.