### PR TITLE
adding capabilities flag for /getconfig/ncclient

### DIFF
--- a/netpalm/backend/core/models/ncclient.py
+++ b/netpalm/backend/core/models/ncclient.py
@@ -20,6 +20,7 @@ class NcclientGetConfigArgs(BaseModel):
     source: str
     filter: Optional[str] = None
     render_json: Optional[bool] = False
+    capabilities: Optional[bool] = False
 
 
 class NcclientGetRpcArgs(BaseModel):
@@ -110,7 +111,8 @@ class NcclientGetConfig(BaseModel):
                     "source": "running",
                     "filter":
                     "<filter type='subtree'><System xmlns='http://cisco.com/ns/yang/cisco-nx-os-device'></System></filter>",
-                    "render_json": True
+                    "render_json": True,
+                    "capabilities": True
                 },
                 "queue_strategy": "fifo",
                 "cache": {

--- a/netpalm/backend/core/models/ncclient.py
+++ b/netpalm/backend/core/models/ncclient.py
@@ -26,6 +26,7 @@ class NcclientGetConfigArgs(BaseModel):
 class NcclientGetRpcArgs(BaseModel):
     rpc: str
     render_json: Optional[bool] = False
+    capabilities: Optional[bool] = False
 
 
 class NcclientDeviceDrivers(str):

--- a/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
+++ b/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
@@ -20,6 +20,14 @@ class ncclien:
         except Exception as e:
             write_meta_error(f"{e}")
 
+    @staticmethod
+    def get_capabilities(session=False):
+        try:
+            capabilities = session.server_capabilities
+            return capabilities
+        except Exception as e:
+            write_meta_error(f"{e}")
+
     def getmethod(self, session=False, command=False):
         try:
             result = {}
@@ -51,6 +59,10 @@ class ncclien:
                 if self.kwarg.get("render_json", False):
                     del self.kwarg["render_json"]
                     rjsflag = True
+                if self.kwarg.get("capabilities", False):
+                    del self.kwarg["capabilities"]
+                    result["capabilities"] = self.get_capabilities(
+                        session=session)
                 # check whether RPC required
                 if self.kwarg.get("rpc", False):
                     response = session.rpc(**self.kwarg).data_xml

--- a/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
+++ b/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
@@ -33,9 +33,10 @@ class ncclien:
             result = {}
             if self.kwarg:
                 rjsflag = False
-                if self.kwarg.get("render_json"):
-                    rjsflag = True
-                del self.kwarg["render_json"]
+                if "render_json" in self.kwarg:
+                    if self.kwarg.get("render_json"):
+                        rjsflag = True
+                    del self.kwarg["render_json"]
                 response = session.get(**self.kwarg).data_xml
                 if rjsflag:
                     respdict = xmltodict.parse(response)
@@ -57,14 +58,16 @@ class ncclien:
             if self.kwarg:
                 rjsflag = False
 
-                # pydantic is defaulting these to false
-                if self.kwarg.get("render_json"):
-                    rjsflag = True
-                if self.kwarg.get("capabilities"):
-                    result["capabilities"] = self.get_capabilities(
-                        session=session)
-                del self.kwarg["render_json"]
-                del self.kwarg["capabilities"]
+                if "render_json" in self.kwarg:
+                    if self.kwarg.get("render_json"):
+                        rjsflag = True
+                    del self.kwarg["render_json"]
+
+                if "capabilities" in self.kwarg:
+                    if self.kwarg.get("capabilities"):
+                        result["capabilities"] = self.get_capabilities(
+                            session=session)
+                    del self.kwarg["capabilities"]
 
                 # check whether RPC required
                 if self.kwarg.get("rpc", False):
@@ -91,10 +94,10 @@ class ncclien:
             result = {}
             if self.kwarg:
                 rjsflag = False
-                # pydantic is defaulting these to false
-                if self.kwarg.get("render_json"):
-                    rjsflag = True
-                del self.kwarg["render_json"]
+                if "render_json" in self.kwarg:
+                    if self.kwarg.get("render_json"):
+                        rjsflag = True
+                    del self.kwarg["render_json"]
                 # edit_config returns an RPCReply object which doesnt have a
                 # data_xml property. Fixes 'Unserializable return value'
                 # message from rq.job:restore

--- a/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
+++ b/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
@@ -33,9 +33,9 @@ class ncclien:
             result = {}
             if self.kwarg:
                 rjsflag = False
-                if self.kwarg.get("render_json", False):
-                    del self.kwarg["render_json"]
+                if self.kwarg.get("render_json"):
                     rjsflag = True
+                del self.kwarg["render_json"]
                 response = session.get(**self.kwarg).data_xml
                 if rjsflag:
                     respdict = xmltodict.parse(response)
@@ -56,13 +56,16 @@ class ncclien:
             result = {}
             if self.kwarg:
                 rjsflag = False
-                if self.kwarg.get("render_json", False):
-                    del self.kwarg["render_json"]
+
+                # pydantic is defaulting these to false
+                if self.kwarg.get("render_json"):
                     rjsflag = True
-                if self.kwarg.get("capabilities", False):
-                    del self.kwarg["capabilities"]
+                if self.kwarg.get("capabilities"):
                     result["capabilities"] = self.get_capabilities(
                         session=session)
+                del self.kwarg["render_json"]
+                del self.kwarg["capabilities"]
+
                 # check whether RPC required
                 if self.kwarg.get("rpc", False):
                     response = session.rpc(**self.kwarg).data_xml
@@ -88,9 +91,10 @@ class ncclien:
             result = {}
             if self.kwarg:
                 rjsflag = False
-                if self.kwarg.get("render_json", False):
-                    del self.kwarg["render_json"]
+                # pydantic is defaulting these to false
+                if self.kwarg.get("render_json"):
                     rjsflag = True
+                del self.kwarg["render_json"]
                 # edit_config returns an RPCReply object which doesnt have a
                 # data_xml property. Fixes 'Unserializable return value'
                 # message from rq.job:restore


### PR DESCRIPTION
Adding a capabilities flag to /getconfig/ncclient so we can get netconf capabilities of the target devices.

I figured this was better than adding an entire new endpoint.