### PR TITLE
removing log entries that show sensitive information on the console

### DIFF
--- a/netpalm/backend/core/redis/rediz.py
+++ b/netpalm/backend/core/redis/rediz.py
@@ -385,7 +385,6 @@ class Rediz:
 
     def execute_service_task(self, metho, **kwargs):
         """service wrapper for execute task method"""
-        log.info(kwargs)
         kw = kwargs.get("kwargs")
         resul = self.execute_task(method=metho, kwargs=kw)
         serv = self.create_service_instance(raw_data=kw)

--- a/netpalm/backend/plugins/calls/getconfig/exec_command.py
+++ b/netpalm/backend/plugins/calls/getconfig/exec_command.py
@@ -14,7 +14,6 @@ log = logging.getLogger(__name__)
 
 def exec_command(**kwargs):
     """main function for executing getconfig commands to southbound drivers"""
-    log.debug(f'called w/ {kwargs}')
     lib = kwargs.get("library", False)
     command = kwargs.get("command", False)
     webhook = kwargs.get("webhook", False)

--- a/netpalm/backend/plugins/calls/getconfig/ncclient_get.py
+++ b/netpalm/backend/plugins/calls/getconfig/ncclient_get.py
@@ -8,7 +8,6 @@ log = logging.getLogger(__name__)
 
 def ncclient_get(**kwargs):
     """main function for executing getconfig commands to southbound drivers"""
-    log.debug(f'called w/ {kwargs}')
     lib = kwargs.get("library", False)
 
     result = False

--- a/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
+++ b/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
@@ -14,7 +14,6 @@ class ncclien:
 
     def connect(self):
         try:
-            log.info(self.connection_args)
             conn = manager.connect(**self.connection_args)
             return conn
         except Exception as e:

--- a/netpalm/routers/route_utils.py
+++ b/netpalm/routers/route_utils.py
@@ -210,7 +210,6 @@ def error_handle_w_cache(f):
     @HttpErrorHandler()
     @cacheable_model
     def wrapper(*args, **kwargs):
-        log.info(f"{args=}, {kwargs=}")
         return f(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
These log entries show user passwords on the console. Anyone with system access can potentially see other users passwords.  I would like to remove these as these should only really be used when doing debugging.