### PR TITLE
Fix Script runner exceptions

### DIFF
--- a/netpalm/backend/plugins/calls/scriptrunner/script.py
+++ b/netpalm/backend/plugins/calls/scriptrunner/script.py
@@ -1,7 +1,10 @@
 import importlib
 
 from netpalm.backend.core.confload.confload import config
-from netpalm.backend.core.utilities.rediz_meta import render_netpalm_payload, write_mandatory_meta
+from netpalm.backend.core.utilities.rediz_meta import (
+    render_netpalm_payload,
+    write_mandatory_meta,
+)
 from netpalm.backend.core.utilities.rediz_meta import write_meta_error
 from netpalm.backend.plugins.utilities.webhook.webhook import exec_webhook_func
 
@@ -9,19 +12,16 @@ from netpalm.backend.plugins.utilities.webhook.webhook import exec_webhook_func
 class script_kiddy:
     def __init__(self, **kwargs):
         self.scrp_path = config.custom_scripts
-        self.kwarg = kwargs.get('kwargs', False)
-        self.arg = self.kwarg.get('args', False)
-        self.script = self.kwarg.get('script', False)
-        self.script_name = self.scrp_path.replace('/', '.') + self.script
+        self.kwarg = kwargs.get("kwargs", False)
+        self.arg = self.kwarg.get("args", False)
+        self.script = self.kwarg.get("script", False)
+        self.script_name = self.scrp_path.replace("/", ".") + self.script
 
     def s_exec(self):
-        try:
-            module = importlib.import_module(self.script_name)
-            runscrp = getattr(module, "run")
-            res = runscrp(kwargs=self.arg)
-            return res
-        except Exception as e:
-            return e
+        module = importlib.import_module(self.script_name)
+        runscrp = getattr(module, "run")
+        res = runscrp(kwargs=self.arg)
+        return res
 
 
 def script_exec(**kwargs):

--- a/netpalm/backend/plugins/calls/scriptrunner/script.py
+++ b/netpalm/backend/plugins/calls/scriptrunner/script.py
@@ -1,10 +1,7 @@
 import importlib
 
 from netpalm.backend.core.confload.confload import config
-from netpalm.backend.core.utilities.rediz_meta import (
-    render_netpalm_payload,
-    write_mandatory_meta,
-)
+from netpalm.backend.core.utilities.rediz_meta import render_netpalm_payload, write_mandatory_meta
 from netpalm.backend.core.utilities.rediz_meta import write_meta_error
 from netpalm.backend.plugins.utilities.webhook.webhook import exec_webhook_func
 
@@ -12,10 +9,10 @@ from netpalm.backend.plugins.utilities.webhook.webhook import exec_webhook_func
 class script_kiddy:
     def __init__(self, **kwargs):
         self.scrp_path = config.custom_scripts
-        self.kwarg = kwargs.get("kwargs", False)
-        self.arg = self.kwarg.get("args", False)
-        self.script = self.kwarg.get("script", False)
-        self.script_name = self.scrp_path.replace("/", ".") + self.script
+        self.kwarg = kwargs.get('kwargs', False)
+        self.arg = self.kwarg.get('args', False)
+        self.script = self.kwarg.get('script', False)
+        self.script_name = self.scrp_path.replace('/', '.') + self.script
 
     def s_exec(self):
         module = importlib.import_module(self.script_name)

--- a/netpalm/backend/plugins/extensibles/custom_scripts/hello_world.py
+++ b/netpalm/backend/plugins/extensibles/custom_scripts/hello_world.py
@@ -1,5 +1,4 @@
-
-#all functions need to be wrapped in the "run" function and pass in kwargs
+# all functions need to be wrapped in the "run" function and pass in kwargs
 # JSON example to send into the /script route is as below
 #
 # {
@@ -14,8 +13,10 @@ def run(**kwargs):
         # mandatory get of kwargs - payload comes through as {"kwargs": {"hello": "world"}}
         args = kwargs.get("kwargs")
         # access your vars here in a dict format - payload is now {"hello": "world"}
-        world = args.get("hello")
-        #reutn "world"
+        world = args["hello"]
+        # reutn "world"
         return world
+    except KeyError as e:
+        raise Exception(f"Required args: {e}")
     except Exception as e:
-        return e
+        raise Exception(e)

--- a/netpalm/backend/plugins/extensibles/custom_scripts/hello_world_two.py
+++ b/netpalm/backend/plugins/extensibles/custom_scripts/hello_world_two.py
@@ -1,5 +1,4 @@
-
-#all functions need to be wrapped in the "run" function and pass in kwargs
+# all functions need to be wrapped in the "run" function and pass in kwargs
 # JSON example to send into the /script route is as below
 #
 # {
@@ -14,8 +13,10 @@ def run(**kwargs):
         # mandatory get of kwargs - payload comes through as {"kwargs": {"hello": "world"}}
         args = kwargs.get("kwargs")
         # access your vars here in a dict format - payload is now {"yes": "world"}
-        world = args.get("yes")
-        #reutn "world"
+        world = args["yes"]
+        # reutn "world"
         return world
+    except KeyError as e:
+        raise Exception(f"Required args: {e}")
     except Exception as e:
-        return e
+        raise Exception(e)

--- a/tests/integration/test_script.py
+++ b/tests/integration/test_script.py
@@ -8,14 +8,24 @@ helper = NetpalmTestHelper()
 
 @pytest.mark.script
 def test_exec_script():
-    pl = {"script": "hello_world", "args": {"hello": "world"}}
+    pl = {
+        "script":"hello_world",
+        "args":{
+            "hello":"world"
+        }
+    }
     res = helper.post_and_check("/script", pl)
     assert res == "world"
 
 
 @pytest.mark.script
 def test_exec_script_failure():
-    pl = {"script": "hello_world", "args": {"bad": "args"}}
+    pl = {
+        "script":"hello_world",
+        "args":{
+            "bad":"args"
+        }
+    }
     res = helper.post_and_check("/script", pl)
     res2 = helper.post_and_check_errors("/script", pl)
     assert res is None

--- a/tests/integration/test_script.py
+++ b/tests/integration/test_script.py
@@ -5,14 +5,18 @@ from tests.integration.helper import NetpalmTestHelper
 
 helper = NetpalmTestHelper()
 
+
 @pytest.mark.script
 def test_exec_script():
-    pl = {
-        "script":"hello_world",
-        "args":{
-            "hello":"world"
-        }
-    }
-    res = helper.post_and_check('/script',pl)
+    pl = {"script": "hello_world", "args": {"hello": "world"}}
+    res = helper.post_and_check("/script", pl)
     assert res == "world"
 
+
+@pytest.mark.script
+def test_exec_script_failure():
+    pl = {"script": "hello_world", "args": {"bad": "args"}}
+    res = helper.post_and_check("/script", pl)
+    res2 = helper.post_and_check_errors("/script", pl)
+    assert res is None
+    assert res2 == ["Required args: 'hello'"]


### PR DESCRIPTION
Fixes issue #169  Remove try/except on s_exec method to allow exemptions to be raised and indicate a failure in execution.  Otherwise, scripts always complete with no errors.

Updated the integration test `test_script.py` as well as the included hello_world scripts to raise an exception on KeyErr (missing required arg).  The full tests outlined in the docs didn't seem to behave the way I expected, but I did test with `pytest tests/integration/test_script.py` from the dev controller container and it passed there.

The demo hello_world scripts would still work the way they were, I only changed them to allow an exception and test the failure scenario.