### PR TITLE
Refactored how worker IDs are generated to be more human-readable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,10 @@
 .git
+.github
+.gitignore
+.idea
+.vscode
+venv
+backend/plugins/extensibles/ntc-templates
 static
+docker-compose*.yml
+dockerfiles

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-backend/plugins/extensibles/ntc-templates/
-*.pyc
-backend/plugins/extensibles/ntc-templates
 .vscode/
 .vscode/settings.json
+.idea
+*.pyc
+venv
+backend/plugins/extensibles/ntc-templates/
+backend/plugins/extensibles/ntc-templates

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -29,6 +29,8 @@ services:
       - redis
     networks:
       - "netpalm-network"
+#    deploy:
+#      replicas: 2
 
   worker-fifo:
     image: netpalm_netpalm-controller

--- a/netpalm/requirements.txt
+++ b/netpalm/requirements.txt
@@ -19,3 +19,4 @@ jsonpath_ng
 apscheduler==3.6.3
 puresnmp==1.9.1
 pydantic
+names_generator==0.1.0


### PR DESCRIPTION
replaces worker names like:  `fifo_7_3e3f79d9-4cb5-415e-9789-5176f3362623` with names like: `thirsty_agnesi_fifo_7`

It also uses the hostname as the seed for the random function so that processes from the same node always have the same random component.  This is okay because each worker type already has uniqueness built into the names (either they have an index, or they have a suitably unique queue name, or are only created once per worker, etc.) for easy understanding of which processes share a node.