### PR TITLE
Refactor exception handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,10 @@
 .git
+.github
+.gitignore
+.idea
+.vscode
+venv
+backend/plugins/extensibles/ntc-templates
 static
+docker-compose*.yml
+dockerfiles

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-backend/plugins/extensibles/ntc-templates/
-*.pyc
-backend/plugins/extensibles/ntc-templates
 .vscode/
 .vscode/settings.json
+.idea
+*.pyc
+venv
+backend/plugins/extensibles/ntc-templates/
+backend/plugins/extensibles/ntc-templates

--- a/RUNNING_TESTS.md
+++ b/RUNNING_TESTS.md
@@ -89,6 +89,10 @@ docker-compose command to force this to background, but it's handy to see this o
 
 ## Running Cisgo tests
 
+```
+docker-compose -f docker-compose.ci.yml exec netpalm-controller pytest -m "not fulllab" -vv tests/integration
+```
+
 We'll actually run our tests from another terminal now.
 
 We're actually going to execute these from inside the controller container. 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -53,6 +53,8 @@ services:
 
   cisgo:
     image: apcela/cisshgo:v0.1.1
+    ports:
+        - "10005:10005"  # one port just for convenience in case you need to ssh from outside for some reason
     networks:
       - "netpalm-network"
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -52,7 +52,7 @@ services:
       - "netpalm-network"
 
   cisgo:
-    image: apcela/cisshgo:v0.1.0
+    image: apcela/cisshgo:v0.1.1
     networks:
       - "netpalm-network"
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -29,6 +29,8 @@ services:
       - redis
     networks:
       - "netpalm-network"
+#    deploy:
+#      replicas: 2
 
   worker-fifo:
     image: netpalm_netpalm-controller

--- a/netpalm/backend/core/models/task.py
+++ b/netpalm/backend/core/models/task.py
@@ -29,7 +29,7 @@ class TaskMetaData(BaseModel):
 
 class TaskError(BaseModel):
     exception_class: str
-    exception_args: [List[str]]
+    exception_args: List[str]
 
 
 class TaskResponse(BaseModel):

--- a/netpalm/backend/core/models/task.py
+++ b/netpalm/backend/core/models/task.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional, Any, List, Union
+from typing import Optional, Any, List, Union, Dict
 
 from pydantic import BaseModel
 
@@ -32,6 +32,16 @@ class TaskError(BaseModel):
     exception_args: List[str]
 
 
+TaskErrorList = List[Union[str, TaskError]]
+
+class ServiceTaskHostError(BaseModel):
+    task_id: str
+    task_errors: TaskErrorList
+
+
+ServiceTaskErrors = List[Dict[str, ServiceTaskHostError]]
+
+
 class TaskResponse(BaseModel):
     task_id: str
     created_on: str
@@ -39,7 +49,7 @@ class TaskResponse(BaseModel):
     task_meta: Optional[TaskMetaData] = None
     task_status: TaskStatusEnum
     task_result: Any
-    task_errors: List[Union[str, TaskError]]
+    task_errors: Union[TaskErrorList, ServiceTaskErrors]  # Needed to get service tasks to validate when they're polled from /task/:taskid
 
 
 class Response(BaseModel):

--- a/netpalm/backend/core/models/task.py
+++ b/netpalm/backend/core/models/task.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional, Any
+from typing import Optional, Any, List, Union
 
 from pydantic import BaseModel
 
@@ -18,11 +18,6 @@ class TaskStatusEnum(str, Enum):
     scheduled = "scheduled"
 
 
-class TaskMeta(BaseModel):
-    result: str
-    errors: list
-
-
 class TaskMetaData(BaseModel):
     enqueued_at: Optional[str]
     started_at: Optional[str]
@@ -32,6 +27,11 @@ class TaskMetaData(BaseModel):
     assigned_worker: Optional[str]
 
 
+class TaskError(BaseModel):
+    exception_class: str
+    exception_args: [List[str]]
+
+
 class TaskResponse(BaseModel):
     task_id: str
     created_on: str
@@ -39,7 +39,7 @@ class TaskResponse(BaseModel):
     task_meta: Optional[TaskMetaData] = None
     task_status: TaskStatusEnum
     task_result: Any
-    task_errors: list
+    task_errors: List[Union[str, TaskError]]
 
 
 class Response(BaseModel):

--- a/netpalm/backend/core/utilities/rediz_meta.py
+++ b/netpalm/backend/core/utilities/rediz_meta.py
@@ -4,10 +4,7 @@ from rq import get_current_job
 
 from netpalm.backend.core.confload.confload import config
 from netpalm.backend.core.models.task import Response
-
-
-class NetpalmMetaProcessedException(Exception):
-    pass
+from netpalm.exceptions import NetpalmMetaProcessedException
 
 
 def exception_full_name(exception: BaseException):

--- a/netpalm/backend/core/utilities/rediz_meta.py
+++ b/netpalm/backend/core/utilities/rediz_meta.py
@@ -1,17 +1,56 @@
+import inspect
+
 from rq import get_current_job
 
 from netpalm.backend.core.confload.confload import config
 from netpalm.backend.core.models.task import Response
 
 
-def write_meta_error(data):
+class NetpalmMetaProcessedException(Exception):
+    pass
+
+
+def exception_full_name(exception: BaseException):
+    name = exception.__class__.__name__
+    if (module := inspect.getmodule(exception)) is None:
+        return name
+
+    name = f'{module.__name__}.{name}'
+    return name
+
+
+def yield_exception_chain(exc: BaseException):
+    yield exc
+    if exc.__cause__ is None:
+        return
+    yield from yield_exception_chain(exc.__cause__)
+
+
+def write_meta_error(exception: Exception):
+    """custom exception handler for within an rpc job"""
+    if isinstance(exception, NetpalmMetaProcessedException):
+        return  # Don't process the same exception twice
+    job = get_current_job()
+    job.meta["result"] = "failed"
+
+    exception_chain = yield_exception_chain(exception)
+
+    for exception in reversed(list(exception_chain)):
+        task_error = {
+            'exception_class': exception_full_name(exception),
+            'exception_args': exception.args
+        }
+        job.meta["errors"].append(task_error)
+
+    job.save_meta()
+    raise NetpalmMetaProcessedException from exception
+
+
+def write_meta_error_string(data):
     """custom exception handler for within an rpc job"""
     job = get_current_job()
     job.meta["result"] = "failed"
-    if type(data) == list:
-        job.meta["errors"].append(data.split('\n'))
-    else:
-        job.meta["errors"].append(data)
+    job.meta["errors"].append(data)
     job.save_meta()
     raise Exception(f"failed: {data}")
 

--- a/netpalm/backend/core/utilities/rediz_meta.py
+++ b/netpalm/backend/core/utilities/rediz_meta.py
@@ -21,15 +21,16 @@ def exception_full_name(exception: BaseException):
 
 def yield_exception_chain(exc: BaseException):
     yield exc
-    if exc.__cause__ is None:
+    if exc.__context__ is None:
         return
-    yield from yield_exception_chain(exc.__cause__)
+    yield from yield_exception_chain(exc.__context__)
 
 
 def write_meta_error(exception: Exception):
     """custom exception handler for within an rpc job"""
     if isinstance(exception, NetpalmMetaProcessedException):
-        return  # Don't process the same exception twice
+        raise exception from None  # Don't process the same exception twice
+
     job = get_current_job()
     job.meta["result"] = "failed"
 

--- a/netpalm/backend/plugins/calls/dryrun/dryrun.py
+++ b/netpalm/backend/plugins/calls/dryrun/dryrun.py
@@ -50,6 +50,6 @@ def dryrun(**kwargs):
             exec_webhook_func(jobdata=current_jobdata, webhook_payload=webhook)
 
     except Exception as e:
-        write_meta_error(f"{e}")
+        write_meta_error(e)
 
     return result

--- a/netpalm/backend/plugins/calls/getconfig/exec_command.py
+++ b/netpalm/backend/plugins/calls/getconfig/exec_command.py
@@ -1,13 +1,14 @@
 import logging
 
 from netpalm.backend.core.utilities.rediz_meta import render_netpalm_payload, write_mandatory_meta
-from netpalm.backend.core.utilities.rediz_meta import write_meta_error_string, write_meta_error
+from netpalm.backend.core.utilities.rediz_meta import write_meta_error
 from netpalm.backend.plugins.drivers.napalm.napalm_drvr import naplm
 from netpalm.backend.plugins.drivers.ncclient.ncclient_drvr import ncclien
 from netpalm.backend.plugins.drivers.netmiko.netmiko_drvr import netmko
 from netpalm.backend.plugins.drivers.puresnmp.puresnmp_drvr import pursnmp
 from netpalm.backend.plugins.drivers.restconf.restconf import restconf
 from netpalm.backend.plugins.utilities.webhook.webhook import exec_webhook_func
+from netpalm.exceptions import NetpalmCheckError
 
 log = logging.getLogger(__name__)
 
@@ -71,10 +72,11 @@ def exec_command(**kwargs):
                         post_check_result = netmik.sendcommand(sesh, [command])
                         for matchstr in postcheck["match_str"]:
                             if postcheck["match_type"] == "include" and matchstr not in str(post_check_result):
-                                write_meta_error_string(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
+                                raise NetpalmCheckError(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
                             if postcheck["match_type"] == "exclude" and matchstr in str(post_check_result):
-                                write_meta_error_string(f"PostCheck Failed: {matchstr} found in {post_check_result}")
+                                raise NetpalmCheckError(f"PostCheck Failed: {matchstr} found in {post_check_result}")
                 netmik.logout(sesh)
+
             elif lib == "napalm":
                 napl = naplm(**kwargs)
                 sesh = napl.connect()
@@ -86,10 +88,11 @@ def exec_command(**kwargs):
                         post_check_result = napl.sendcommand(sesh, [command])
                         for matchstr in postcheck["match_str"]:
                             if postcheck["match_type"] == "include" and matchstr not in str(post_check_result):
-                                write_meta_error_string(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
+                                raise NetpalmCheckError(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
                             if postcheck["match_type"] == "exclude" and matchstr in str(post_check_result):
-                                write_meta_error_string(f"PostCheck Failed: {matchstr} found in {post_check_result}")
+                                raise NetpalmCheckError(f"PostCheck Failed: {matchstr} found in {post_check_result}")
                 napl.logout(sesh)
+
             elif lib == "ncclient":
                 ncc = ncclien(**kwargs)
                 sesh = ncc.connect()

--- a/netpalm/backend/plugins/calls/getconfig/exec_command.py
+++ b/netpalm/backend/plugins/calls/getconfig/exec_command.py
@@ -1,7 +1,7 @@
 import logging
 
 from netpalm.backend.core.utilities.rediz_meta import render_netpalm_payload, write_mandatory_meta
-from netpalm.backend.core.utilities.rediz_meta import write_meta_error
+from netpalm.backend.core.utilities.rediz_meta import write_meta_error_string, write_meta_error
 from netpalm.backend.plugins.drivers.napalm.napalm_drvr import naplm
 from netpalm.backend.plugins.drivers.ncclient.ncclient_drvr import ncclien
 from netpalm.backend.plugins.drivers.netmiko.netmiko_drvr import netmko
@@ -71,9 +71,9 @@ def exec_command(**kwargs):
                         post_check_result = netmik.sendcommand(sesh, [command])
                         for matchstr in postcheck["match_str"]:
                             if postcheck["match_type"] == "include" and matchstr not in str(post_check_result):
-                                write_meta_error(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
+                                write_meta_error_string(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
                             if postcheck["match_type"] == "exclude" and matchstr in str(post_check_result):
-                                write_meta_error(f"PostCheck Failed: {matchstr} found in {post_check_result}")
+                                write_meta_error_string(f"PostCheck Failed: {matchstr} found in {post_check_result}")
                 netmik.logout(sesh)
             elif lib == "napalm":
                 napl = naplm(**kwargs)
@@ -86,9 +86,9 @@ def exec_command(**kwargs):
                         post_check_result = napl.sendcommand(sesh, [command])
                         for matchstr in postcheck["match_str"]:
                             if postcheck["match_type"] == "include" and matchstr not in str(post_check_result):
-                                write_meta_error(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
+                                write_meta_error_string(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
                             if postcheck["match_type"] == "exclude" and matchstr in str(post_check_result):
-                                write_meta_error(f"PostCheck Failed: {matchstr} found in {post_check_result}")
+                                write_meta_error_string(f"PostCheck Failed: {matchstr} found in {post_check_result}")
                 napl.logout(sesh)
             elif lib == "ncclient":
                 ncc = ncclien(**kwargs)
@@ -105,6 +105,6 @@ def exec_command(**kwargs):
             current_jobdata = render_netpalm_payload(job_result=result)
             exec_webhook_func(jobdata=current_jobdata, webhook_payload=webhook)
     except Exception as e:
-        write_meta_error(f"{e}")
+        write_meta_error(e)
 
     return result

--- a/netpalm/backend/plugins/calls/getconfig/ncclient_get.py
+++ b/netpalm/backend/plugins/calls/getconfig/ncclient_get.py
@@ -23,6 +23,6 @@ def ncclient_get(**kwargs):
         else:
             raise NotImplementedError(f"unknown 'library' parameter {lib}")
     except Exception as e:
-        write_meta_error(f"{e}")
+        write_meta_error(e)
 
     return result

--- a/netpalm/backend/plugins/calls/scriptrunner/script.py
+++ b/netpalm/backend/plugins/calls/scriptrunner/script.py
@@ -34,6 +34,6 @@ def script_exec(**kwargs):
             current_jobdata = render_netpalm_payload(job_result=result)
             exec_webhook_func(jobdata=current_jobdata, webhook_payload=webhook)
     except Exception as e:
-        write_meta_error(f"{e}")
+        write_meta_error(e)
 
     return result

--- a/netpalm/backend/plugins/calls/service/service.py
+++ b/netpalm/backend/plugins/calls/service/service.py
@@ -5,7 +5,7 @@ import json
 import requests
 
 from netpalm.backend.core.confload.confload import config
-from netpalm.backend.core.utilities.rediz_meta import write_meta_error, write_mandatory_meta
+from netpalm.backend.core.utilities.rediz_meta import write_meta_error_string, write_mandatory_meta
 from netpalm.backend.core.models.service import ServiceModelTemplate
 from netpalm.backend.plugins.utilities.jinja2.j2 import render_j2template
 
@@ -47,7 +47,7 @@ class service:
             self.template_json = data
             return True
         except Exception as e:
-            write_meta_error(f"validate_template: {e}")
+            write_meta_error_string(f"validate_template: {e}")
             log.error(f"validate_template: {e}")
 
     def execute_api_call(self, oper, payload):
@@ -68,11 +68,11 @@ class service:
             if res.status_code == 201:
                 return res.json()
             else:
-                write_meta_error(
+                write_meta_error_string(
                     f"error calling self api response {res.status_code}"
                     )
         except Exception as e:
-            write_meta_error(f"execute_api_call service: {e}")
+            write_meta_error_string(f"execute_api_call service: {e}")
             log.error(f"execute_api_call service: {e}")
 
     def execute_service(self):
@@ -121,6 +121,6 @@ def render_service(**kwargs):
         if res:
             exeservice = s.execute_service()
     except Exception as e:
-        write_meta_error(f"render_service: {e}")
+        write_meta_error_string(f"render_service: {e}")
 
     return exeservice

--- a/netpalm/backend/plugins/calls/setconfig/exec_config.py
+++ b/netpalm/backend/plugins/calls/setconfig/exec_config.py
@@ -1,4 +1,5 @@
-from netpalm.backend.core.utilities.rediz_meta import write_meta_error, render_netpalm_payload, write_mandatory_meta
+from netpalm.backend.core.utilities.rediz_meta import write_meta_error_string, render_netpalm_payload, \
+    write_mandatory_meta, write_meta_error
 from netpalm.backend.plugins.drivers.napalm.napalm_drvr import naplm
 from netpalm.backend.plugins.drivers.ncclient.ncclient_drvr import ncclien
 from netpalm.backend.plugins.drivers.netmiko.netmiko_drvr import netmko
@@ -66,10 +67,10 @@ def exec_config(**kwargs):
                         pre_check_result = netmik.sendcommand(sesh, [command])
                         for matchstr in precheck["match_str"]:
                             if precheck["match_type"] == "include" and matchstr not in str(pre_check_result):
-                                write_meta_error(f"PreCheck Failed: {matchstr} not found in {pre_check_result}")
+                                write_meta_error_string(f"PreCheck Failed: {matchstr} not found in {pre_check_result}")
                                 pre_check_ok = False
                             if precheck["match_type"] == "exclude" and matchstr in str(pre_check_result):
-                                write_meta_error(f"PreCheck Failed: {matchstr} found in {pre_check_result}")
+                                write_meta_error_string(f"PreCheck Failed: {matchstr} found in {pre_check_result}")
                                 pre_check_ok = False
                 if pre_check_ok:
                     result = netmik.config(sesh, config, enable_mode)
@@ -79,9 +80,9 @@ def exec_config(**kwargs):
                             post_check_result = netmik.sendcommand(sesh, [command])
                             for matchstr in postcheck["match_str"]:
                                 if postcheck["match_type"] == "include" and matchstr not in str(post_check_result):
-                                    write_meta_error(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
+                                    write_meta_error_string(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
                                 if postcheck["match_type"] == "exclude" and matchstr in str(post_check_result):
-                                    write_meta_error(f"PostCheck Failed: {matchstr} found in {post_check_result}")
+                                    write_meta_error_string(f"PostCheck Failed: {matchstr} found in {post_check_result}")
                 netmik.logout(sesh)
 
             elif lib == "napalm":
@@ -93,10 +94,10 @@ def exec_config(**kwargs):
                         pre_check_result = napl.sendcommand(sesh, [command])
                         for matchstr in precheck["match_str"]:
                             if precheck["match_type"] == "include" and matchstr not in str(pre_check_result):
-                                write_meta_error(f"PreCheck Failed: {matchstr} not found in {pre_check_result}")
+                                write_meta_error_string(f"PreCheck Failed: {matchstr} not found in {pre_check_result}")
                                 pre_check_ok = False
                             if precheck["match_type"] == "exclude" and matchstr in str(pre_check_result):
-                                write_meta_error(f"PreCheck Failed: {matchstr} found in {pre_check_result}")
+                                write_meta_error_string(f"PreCheck Failed: {matchstr} found in {pre_check_result}")
                                 pre_check_ok = False
                 if pre_check_ok:
                     result = napl.config(sesh,config)
@@ -106,9 +107,9 @@ def exec_config(**kwargs):
                             post_check_result = napl.sendcommand(sesh, [command])
                             for matchstr in postcheck["match_str"]:
                                 if postcheck["match_type"] == "include" and matchstr not in str(post_check_result):
-                                    write_meta_error(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
+                                    write_meta_error_string(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
                                 if postcheck["match_type"] == "exclude" and matchstr in str(post_check_result):
-                                    write_meta_error(f"PostCheck Failed: {matchstr} found in {post_check_result}")
+                                    write_meta_error_string(f"PostCheck Failed: {matchstr} found in {post_check_result}")
                 napl.logout(sesh)
 
             elif lib == "ncclient":
@@ -127,6 +128,6 @@ def exec_config(**kwargs):
             exec_webhook_func(jobdata=current_jobdata, webhook_payload=webhook)
 
     except Exception as e:
-        write_meta_error(f"{e}")
+        write_meta_error(e)
 
     return result

--- a/netpalm/backend/plugins/calls/setconfig/exec_config.py
+++ b/netpalm/backend/plugins/calls/setconfig/exec_config.py
@@ -1,11 +1,11 @@
-from netpalm.backend.core.utilities.rediz_meta import write_meta_error_string, render_netpalm_payload, \
-    write_mandatory_meta, write_meta_error
+from netpalm.backend.core.utilities.rediz_meta import render_netpalm_payload, write_mandatory_meta, write_meta_error
 from netpalm.backend.plugins.drivers.napalm.napalm_drvr import naplm
 from netpalm.backend.plugins.drivers.ncclient.ncclient_drvr import ncclien
 from netpalm.backend.plugins.drivers.netmiko.netmiko_drvr import netmko
 from netpalm.backend.plugins.drivers.restconf.restconf import restconf
 from netpalm.backend.plugins.utilities.jinja2.j2 import render_j2template
 from netpalm.backend.plugins.utilities.webhook.webhook import exec_webhook_func
+from netpalm.exceptions import NetpalmCheckError
 
 
 def exec_config(**kwargs):
@@ -67,11 +67,10 @@ def exec_config(**kwargs):
                         pre_check_result = netmik.sendcommand(sesh, [command])
                         for matchstr in precheck["match_str"]:
                             if precheck["match_type"] == "include" and matchstr not in str(pre_check_result):
-                                write_meta_error_string(f"PreCheck Failed: {matchstr} not found in {pre_check_result}")
-                                pre_check_ok = False
+                                raise NetpalmCheckError(f"PreCheck Failed: {matchstr} not found in {pre_check_result}")
                             if precheck["match_type"] == "exclude" and matchstr in str(pre_check_result):
-                                write_meta_error_string(f"PreCheck Failed: {matchstr} found in {pre_check_result}")
-                                pre_check_ok = False
+                                raise NetpalmCheckError(f"PreCheck Failed: {matchstr} found in {pre_check_result}")
+
                 if pre_check_ok:
                     result = netmik.config(sesh, config, enable_mode)
                     if post_checks:
@@ -80,9 +79,9 @@ def exec_config(**kwargs):
                             post_check_result = netmik.sendcommand(sesh, [command])
                             for matchstr in postcheck["match_str"]:
                                 if postcheck["match_type"] == "include" and matchstr not in str(post_check_result):
-                                    write_meta_error_string(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
+                                    raise NetpalmCheckError(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
                                 if postcheck["match_type"] == "exclude" and matchstr in str(post_check_result):
-                                    write_meta_error_string(f"PostCheck Failed: {matchstr} found in {post_check_result}")
+                                    raise NetpalmCheckError(f"PostCheck Failed: {matchstr} found in {post_check_result}")
                 netmik.logout(sesh)
 
             elif lib == "napalm":
@@ -94,11 +93,10 @@ def exec_config(**kwargs):
                         pre_check_result = napl.sendcommand(sesh, [command])
                         for matchstr in precheck["match_str"]:
                             if precheck["match_type"] == "include" and matchstr not in str(pre_check_result):
-                                write_meta_error_string(f"PreCheck Failed: {matchstr} not found in {pre_check_result}")
-                                pre_check_ok = False
+                                raise NetpalmCheckError(f"PreCheck Failed: {matchstr} not found in {pre_check_result}")
                             if precheck["match_type"] == "exclude" and matchstr in str(pre_check_result):
-                                write_meta_error_string(f"PreCheck Failed: {matchstr} found in {pre_check_result}")
-                                pre_check_ok = False
+                                raise NetpalmCheckError(f"PreCheck Failed: {matchstr} found in {pre_check_result}")
+
                 if pre_check_ok:
                     result = napl.config(sesh,config)
                     if post_checks:
@@ -107,9 +105,9 @@ def exec_config(**kwargs):
                             post_check_result = napl.sendcommand(sesh, [command])
                             for matchstr in postcheck["match_str"]:
                                 if postcheck["match_type"] == "include" and matchstr not in str(post_check_result):
-                                    write_meta_error_string(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
+                                    raise NetpalmCheckError(f"PostCheck Failed: {matchstr} not found in {post_check_result}")
                                 if postcheck["match_type"] == "exclude" and matchstr in str(post_check_result):
-                                    write_meta_error_string(f"PostCheck Failed: {matchstr} found in {post_check_result}")
+                                    raise NetpalmCheckError(f"PostCheck Failed: {matchstr} found in {post_check_result}")
                 napl.logout(sesh)
 
             elif lib == "ncclient":

--- a/netpalm/backend/plugins/drivers/napalm/napalm_drvr.py
+++ b/netpalm/backend/plugins/drivers/napalm/napalm_drvr.py
@@ -19,7 +19,7 @@ class naplm:
             napalmses = driver(**self.connection_args)
             return napalmses
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def sendcommand(self, session=False, command=False):
         try:
@@ -34,7 +34,7 @@ class naplm:
                     result[c] = response[c].split("\n")
             return result
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def config(self, session=False, command=False, dry_run=False):
         try:
@@ -55,11 +55,11 @@ class naplm:
             result["changes"] = diff.split("\n")
             return result
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def logout(self, session):
         try:
             response = session.close()
             return response
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)

--- a/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
+++ b/netpalm/backend/plugins/drivers/ncclient/ncclient_drvr.py
@@ -2,7 +2,7 @@ import xmltodict
 import logging
 from ncclient import manager
 
-from netpalm.backend.core.utilities.rediz_meta import write_meta_error
+from netpalm.backend.core.utilities.rediz_meta import write_meta_error_string, write_meta_error
 
 log = logging.getLogger(__name__)
 
@@ -17,7 +17,7 @@ class ncclien:
             conn = manager.connect(**self.connection_args)
             return conn
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     @staticmethod
     def get_capabilities(session=False):
@@ -25,7 +25,7 @@ class ncclien:
             capabilities = session.server_capabilities
             return capabilities
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def getmethod(self, session=False, command=False):
         try:
@@ -42,14 +42,14 @@ class ncclien:
                     if respdict:
                         result["get_config"] = respdict
                     else:
-                        write_meta_error("failed to parse response")
+                        write_meta_error_string("failed to parse response")
                 else:
                     result["get_config"] = response
             else:
-                write_meta_error("args are required")
+                write_meta_error_string("args are required")
             return result
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def getconfig(self, session=False, command=False):
         try:
@@ -79,14 +79,14 @@ class ncclien:
                     if respdict:
                         result["get_config"] = respdict
                     else:
-                        write_meta_error("failed to parse response")
+                        write_meta_error_string("failed to parse response")
                 else:
                     result["get_config"] = response
             else:
-                write_meta_error("args are required")
+                write_meta_error_string("args are required")
             return result
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def editconfig(self, session=False, dry_run=False):
         try:
@@ -110,18 +110,18 @@ class ncclien:
                     if respdict:
                         result["edit_config"] = respdict
                     else:
-                        write_meta_error("failed to parse response")
+                        write_meta_error_string("failed to parse response")
                 else:
                     result["edit_config"] = response
             else:
-                write_meta_error("args are required")
+                write_meta_error_string("args are required")
             return result
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def logout(self, session):
         try:
             response = session.close_session()
             return response
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)

--- a/netpalm/backend/plugins/drivers/netmiko/netmiko_drvr.py
+++ b/netpalm/backend/plugins/drivers/netmiko/netmiko_drvr.py
@@ -25,7 +25,7 @@ class netmko:
             netmikoses = ConnectHandler(**self.connection_args)
             return netmikoses
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def sendcommand(self, session=False, command=False):
         try:
@@ -46,7 +46,7 @@ class netmko:
                         result[commands] = response.split("\n")
             return result
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def config(self,
                session=False,
@@ -79,7 +79,7 @@ class netmko:
                     except AttributeError:
                         pass
                     except Exception as e:
-                        write_meta_error(f"{e}")
+                        write_meta_error(e)
 
                 elif hasattr(session, "save_config") and callable(
                         session.save_config):
@@ -88,17 +88,17 @@ class netmko:
                     except AttributeError:
                         pass
                     except Exception as e:
-                        write_meta_error(f"{e}")
+                        write_meta_error(e)
 
             result = {}
             result["changes"] = response.split("\n")
             return result
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def logout(self, session):
         try:
             response = session.disconnect()
             return response
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)

--- a/netpalm/backend/plugins/drivers/puresnmp/puresnmp_drvr.py
+++ b/netpalm/backend/plugins/drivers/puresnmp/puresnmp_drvr.py
@@ -20,7 +20,7 @@ class pursnmp:
         try:
             return True
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def sendcommand(self, session=False, command=False):
         try:
@@ -70,16 +70,16 @@ class pursnmp:
                     result[c] = f"{response}"
             return result
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def config(self, session=False, command=False, dry_run=False):
         try:
             return True
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def logout(self, session):
         try:
             return True
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)

--- a/netpalm/backend/plugins/drivers/restconf/restconf.py
+++ b/netpalm/backend/plugins/drivers/restconf/restconf.py
@@ -34,7 +34,7 @@ class restconf:
                 del self.connection_args["headers"]
             return True
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def sendcommand(self, session=False, command=False):
         try:
@@ -52,7 +52,7 @@ class restconf:
             result[url]["result"] = res
             return result
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def config(self, session=False, command=False):
         try:
@@ -72,10 +72,10 @@ class restconf:
             else:
                 raise Exception(self.action + " not found in requests") 
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)
 
     def logout(self, session):
         try:
             return True
         except Exception as e:
-            write_meta_error(f"{e}")
+            write_meta_error(e)

--- a/netpalm/exceptions.py
+++ b/netpalm/exceptions.py
@@ -1,0 +1,18 @@
+
+class NetpalmError(Exception):
+    """Baseclass for all netpalm errors"""
+    pass
+
+
+class NetpalmDriverError(NetpalmError):
+    """Errors related to driver plugins"""
+    pass
+
+
+class NetpalmCheckError(NetpalmError):
+    """Errors due to pre or post check validation failure"""
+    pass
+
+
+class NetpalmMetaProcessedException(NetpalmError):
+    pass

--- a/netpalm/requirements.txt
+++ b/netpalm/requirements.txt
@@ -19,3 +19,4 @@ jsonpath_ng
 apscheduler==3.6.3
 puresnmp==1.9.1
 pydantic
+names_generator==0.1.0

--- a/netpalm/routers/task.py
+++ b/netpalm/routers/task.py
@@ -12,7 +12,7 @@ router = APIRouter()
 
 
 # get specific task
-@router.get("/task/{task_id}", response_model=Response)
+@router.get("/task/{task_id}", response_model=Response)  # this can *also* return ServiceResponse, but trying to typdef it doesn't seem to work
 def get_task(task_id: str):
     try:
         r = ntplm.fetchtask(task_id=task_id)

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from json import JSONDecodeError
 
 import requests
 from typing import Dict, Tuple, List
@@ -92,7 +93,13 @@ class NetpalmTestHelper:
         url = f"{self.base_url}{endpoint}"
         r = requests.post(url, json=payload, headers=self.headers, timeout=self.http_timeout)
         r.raise_for_status()
-        task_id = r.json()["data"]["task_id"]
+        try:
+            task_id = r.json()["data"]["task_id"]
+
+        except JSONDecodeError:
+            log.error(f"Can't JSON decode response:\n{r.text}")
+            raise
+
         result, errors = self.poll_task(task_id)
         return result
 

--- a/tests/integration/test_getconfig.py
+++ b/tests/integration/test_getconfig.py
@@ -42,8 +42,7 @@ def test_getconfig_napalm_post_check():
         },
         "command":
         "show run | i hostname",
-        "queue_strategy":
-        "pinned",
+        "queue_strategy": "pinned",
         "post_checks": [{
             "match_type": "include",
             "get_config_args": {

--- a/tests/integration/test_getconfig_cisgo.py
+++ b/tests/integration/test_getconfig_cisgo.py
@@ -84,11 +84,27 @@ def hostname_from_config(config_lines: Union[List[str], str]) -> str:
 
 @pytest.mark.getconfig
 @pytest.mark.cisgo
-def test_getconfig_netmiko(cisgo_helper: CisgoHelper):
+def test_getconfig_netmiko_fifo(cisgo_helper: CisgoHelper):
     pl = {
         "library": "netmiko",
         "connection_args": cisgo_helper.netmiko_connection_args,
         "command": "show running-config",
+        # "cache": {"enabled": False}
+    }
+    res = helper.post_and_check('/getconfig', pl)
+    assert hostname_from_config(res["show running-config"]) == CISGO_DEFAULT_HOSTNAME
+    res = helper.post_and_check('/get', pl)
+    assert hostname_from_config(res["show running-config"]) == CISGO_DEFAULT_HOSTNAME
+
+
+@pytest.mark.getconfig
+@pytest.mark.cisgo
+def test_getconfig_netmiko_pinned(cisgo_helper: CisgoHelper):
+    pl = {
+        "library": "netmiko",
+        "connection_args": cisgo_helper.netmiko_connection_args,
+        "command": "show running-config",
+        "queue_strategy": "pinned",
         # "cache": {"enabled": False}
     }
     res = helper.post_and_check('/getconfig', pl)

--- a/tests/integration/test_script.py
+++ b/tests/integration/test_script.py
@@ -29,4 +29,4 @@ def test_exec_script_failure():
     res = helper.post_and_check("/script", pl)
     res2 = helper.post_and_check_errors("/script", pl)
     assert res is None
-    assert res2 == ["Required args: 'hello'"]
+    assert res2 == [{"exception_args": ["Required args: 'hello'"], 'exception_class': 'Exception'}]

--- a/tests/integration/test_script.py
+++ b/tests/integration/test_script.py
@@ -29,4 +29,15 @@ def test_exec_script_failure():
     res = helper.post_and_check("/script", pl)
     res2 = helper.post_and_check_errors("/script", pl)
     assert res is None
-    assert res2 == [{"exception_args": ["Required args: 'hello'"], 'exception_class': 'Exception'}]
+    assert res2 == [
+        # "Required args: 'hello'"
+
+        {
+            "exception_args": ["hello"],
+            "exception_class": "KeyError"
+        },
+        {
+            "exception_args": ["Required args: 'hello'"],
+            "exception_class": "Exception"
+        }
+    ]

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -22,8 +22,7 @@ def test_prepare_vlan_service_environment():
     }
     reslist = helper.post_and_check('/service/vlan_service',pl)
     res = helper.check_many(reslist)
-    if res:
-        assert True
+    assert res
         
 @pytest.mark.service
 def test_create_vlan_service_instance():

--- a/tests/unit/test_napalm_driver.py
+++ b/tests/unit/test_napalm_driver.py
@@ -5,7 +5,7 @@ from napalm.base.base import NetworkDriver
 import pytest
 from pytest_mock import MockerFixture
 
-from netpalm.backend.core.utilities.rediz_meta import NetpalmMetaProcessedException
+from netpalm.exceptions import NetpalmMetaProcessedException
 from netpalm.backend.plugins.drivers.napalm.napalm_drvr import naplm
 from netpalm.backend.plugins.calls.getconfig.exec_command import exec_command
 

--- a/tests/unit/test_napalm_driver.py
+++ b/tests/unit/test_napalm_driver.py
@@ -5,6 +5,7 @@ from napalm.base.base import NetworkDriver
 import pytest
 from pytest_mock import MockerFixture
 
+from netpalm.backend.core.utilities.rediz_meta import NetpalmMetaProcessedException
 from netpalm.backend.plugins.drivers.napalm.napalm_drvr import naplm
 from netpalm.backend.plugins.calls.getconfig.exec_command import exec_command
 
@@ -155,6 +156,6 @@ def test_napalm_gc_exec_command_post_checks(napalm_get_network_driver: Mock, rq_
                                                              username=NAPALM_C_ARGS["username"],
                                                              password=NAPALM_C_ARGS["password"])
 
-    with pytest.raises(Exception):
+    with pytest.raises(NetpalmMetaProcessedException):
         _ = exec_command(library="napalm", command=command,
                          connection_args=NAPALM_C_ARGS.copy(), post_checks=[bad_post_check])

--- a/tests/unit/test_ncclient_driver.py
+++ b/tests/unit/test_ncclient_driver.py
@@ -5,7 +5,7 @@ from napalm.base.base import NetworkDriver
 import pytest
 from pytest_mock import MockerFixture
 
-from netpalm.backend.core.utilities.rediz_meta import NetpalmMetaProcessedException
+from netpalm.exceptions import NetpalmMetaProcessedException
 from netpalm.backend.plugins.drivers.ncclient.ncclient_drvr import ncclien
 from netpalm.backend.plugins.calls.getconfig.exec_command import exec_command
 

--- a/tests/unit/test_ncclient_driver.py
+++ b/tests/unit/test_ncclient_driver.py
@@ -5,6 +5,7 @@ from napalm.base.base import NetworkDriver
 import pytest
 from pytest_mock import MockerFixture
 
+from netpalm.backend.core.utilities.rediz_meta import NetpalmMetaProcessedException
 from netpalm.backend.plugins.drivers.ncclient.ncclient_drvr import ncclien
 from netpalm.backend.plugins.calls.getconfig.exec_command import exec_command
 
@@ -53,7 +54,7 @@ def test_ncclient_getmethod_empty_args(ncclient_manager: Mock, rq_job):
     c_arg_copy = NCCLIENT_C_ARGS.copy()
     ncclient_driver = ncclien(connection_args=c_arg_copy)
     sesh = ncclient_driver.connect()
-    with pytest.raises(Exception):
+    with pytest.raises(NetpalmMetaProcessedException):
         result = ncclient_driver.getmethod(sesh)
 
 

--- a/tests/unit/test_netmiko_driver.py
+++ b/tests/unit/test_netmiko_driver.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 from pytest_mock import MockerFixture
 
-from netpalm.backend.core.utilities.rediz_meta import NetpalmMetaProcessedException
+from netpalm.exceptions import NetpalmMetaProcessedException
 from netpalm.backend.plugins.drivers.netmiko.netmiko_drvr import netmko
 from netpalm.backend.plugins.calls.getconfig.exec_command import exec_command
 

--- a/tests/unit/test_netmiko_driver.py
+++ b/tests/unit/test_netmiko_driver.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import pytest
 from pytest_mock import MockerFixture
 
+from netpalm.backend.core.utilities.rediz_meta import NetpalmMetaProcessedException
 from netpalm.backend.plugins.drivers.netmiko.netmiko_drvr import netmko
 from netpalm.backend.plugins.calls.getconfig.exec_command import exec_command
 
@@ -127,7 +128,7 @@ def test_netmiko_gc_exec_command_post_checks(netmiko_connection_handler: Mock, r
     for command, value in list(NETMIKO_COMMANDS.items())[:1]:
         assert result[command] == value.splitlines()
 
-    with pytest.raises(Exception):
+    with pytest.raises(NetpalmMetaProcessedException):
         result = exec_command(library="netmiko", command=command, connection_args=NETMIKO_C_ARGS, post_checks=[bad_post_check])
 
 


### PR DESCRIPTION
update `write_meta_error`:

`write_meta_error_string` has exactly same behavior as `write_meta_error` used to.

`write_meta_error`:
  * Acts on Exception objects
  * walks the entire stack trace to discover ancestor exceptions (i.e. if a socket error cause a paramiko error caused a netmiko error caused a napalm error)
  * adds object with "exception_class" and "exception_args" for each error to error list (ensuring "root cause" error is at top of list)
    * `RuntimeError("foo") becomes {"exception_class": "RuntimeError", "exception_args": ["foo"]}`
  
Tweaked Response models to permit this (both directly, and nested as part of ServiceResponse)

