### PR TITLE
Update netmiko_drvr.py

### DIFF
--- a/netpalm/backend/plugins/drivers/netmiko/netmiko_drvr.py
+++ b/netpalm/backend/plugins/drivers/netmiko/netmiko_drvr.py
@@ -34,14 +34,22 @@ class netmko:
             if self.enable_mode:
                 session.enable()
             result = {}
-            for commands in command:
+            
+            if "ttp_template" in self.kwarg.keys():
+                if type(self.kwarg["ttp_template"]) == str:
+                    templatelst = [self.kwarg["ttp_template"]]
+                else:
+                    templatelst = self.kwarg["ttp_template"]
+
+            for idx, commands in enumerate(command):
                 if self.kwarg:
                     # normalise the ttp template name for ease of use
                     if "ttp_template" in self.kwarg.keys():
-                        if self.kwarg["ttp_template"]:
-                            template_name = config.ttp_templates + self.kwarg[
-                                "ttp_template"] + ".ttp"
+                        if idx < len(templatelst):
+                            template_name = config.ttp_templates + templatelst[idx] + ".ttp"
                             self.kwarg["ttp_template"] = template_name
+                        else:
+                            self.kwarg["use_ttp"] = False
                     response = session.send_command(commands, **self.kwarg)
                     if response:
                         result[commands] = response


### PR DESCRIPTION
Add the ability to pass an array to "ttp_template" key in netmiko args. It will match any given command in order with the template. If there's a command without a template, it should be put in the end of the command array, and it will get the raw data.

Example 1, will match command with template, in order (command1 -> template1, command2 -> template2) command: [ 'command1', 'command2' ]
ttp_template: [ 'template1', 'template2' ]

Example 2, will match command with template, and command without template will return the raw data (command1 -> template1, command2 -> raw) command: [ 'command1', 'command2' ]
ttp_template: [ 'template1' ]

If command and ttp_template are a string, they will be encapsulated in an array and will be matched as before.