### PR TITLE
Filter None from exception args

### DIFF
--- a/netpalm/backend/core/utilities/rediz_meta.py
+++ b/netpalm/backend/core/utilities/rediz_meta.py
@@ -41,7 +41,7 @@ def write_meta_error(exception: Exception):
     for exception in reversed(list(exception_chain)):
         task_error = {
             'exception_class': exception_full_name(exception),
-            'exception_args': exception.args
+            'exception_args': [arg for arg in exception.args if arg is not None]
         }
         job.meta["errors"].append(task_error)
 


### PR DESCRIPTION
When retrieving a task result that had failed (unable to connect to device), the response validation was failing and returning a 404.

> netpalm-controller_1     | [2022-10-21 02:31:25,904:netpalm.routers.task:get_task:DEBUG] Response: 6 validation errors for Response
> netpalm-controller_1     | data -> task_errors -> 0
> netpalm-controller_1     |   str type expected (type=type_error.str)
> netpalm-controller_1     | data -> task_errors -> 0 -> exception_args -> 0
> netpalm-controller_1     |   none is not an allowed value (type=type_error.none.not_allowed)
> netpalm-controller_1     | data -> task_errors -> 0 -> exception_class
> netpalm-controller_1     |   value is not a valid dict (type=type_error.dict)
> netpalm-controller_1     | data -> task_errors -> 0 -> exception_args
> netpalm-controller_1     |   value is not a valid dict (type=type_error.dict)
> netpalm-controller_1     | data -> task_errors -> 1 -> exception_class
> netpalm-controller_1     |   value is not a valid dict (type=type_error.dict)
> netpalm-controller_1     | data -> task_errors -> 1 -> exception_args
> netpalm-controller_1     |   value is not a valid dict (type=type_error.dict)

Original task_errors:
`[{'exception_class': 'paramiko.ssh_exception.NoValidConnectionsError',
  'exception_args': (None, 'Unable to connect to port 22 on 172.16.3.3')},
 {'exception_class': 'netmiko.ssh_exception.NetmikoTimeoutException', 'exception_args': (
 'TCP connection to device failed.\n\nCommon causes of this problem are:\n1. Incorrect hostname or IP address.\n2. Wrong TCP port.\n3. Intermediate firewall blocking access.\n\nDevice settings: cisco_ios 172.16.3.3:22\n\n',)}]
`

Filtering None from exception args.

I am not sure if this is the best solution - or if it would be better to update the Model to allow None?