### PR TITLE
Make the requirement of pydantic version more explicit

### DIFF
--- a/netpalm/requirements.txt
+++ b/netpalm/requirements.txt
@@ -18,5 +18,5 @@ filelock
 jsonpath_ng
 apscheduler==3.6.3
 puresnmp==1.9.1
-pydantic
+pydantic>=1.10.13,<2.0
 names_generator==0.1.0

--- a/netpalm/requirements.txt
+++ b/netpalm/requirements.txt
@@ -18,5 +18,5 @@ filelock
 jsonpath_ng
 apscheduler==3.6.3
 puresnmp==1.9.1
-pydantic>=1.10.13,<2.0
+pydantic==1.10.13
 names_generator==0.1.0


### PR DESCRIPTION
As discussed in #206 I am opening this PR to make the requirements of the pydantic version explicit and avoid the docker containers to keep restarting.